### PR TITLE
adjust debounce wait period for setting AC Power state

### DIFF
--- a/src/steamListeners.tsx
+++ b/src/steamListeners.tsx
@@ -98,7 +98,7 @@ let debouncedSetAcPower = debounce((newACState: number) => {
     eACState = newACState;
     store.dispatch(setAcPower(newACState));
   }
-}, 1000);
+}, 60000);
 
 export const acPowerEventListener = () => {
   try {


### PR DESCRIPTION
I tested a few games with varying power demands and power configurations, docked and just charging. 

Tested on Lenovo Legion Go  using the 65W OEM charger.

The default 1000 ms wait is too small, power profiles still bounce back and forth. I had some periods where it took over 35 seconds for the AC power to kick back in. 

The 60 second high ball fixes the issue for me regardless of power draw or game. 

This is mainly to address the strange way the battery limit is implemented on the Lenovo Legion Go.
