### PR TITLE
Merge SteamFork's SimpleDeckyTDP features upstream.

### DIFF
--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -50,16 +50,18 @@ def ryzenadj(tdp: int):
         if advanced_options.get_setting(RogAllySettings.USE_WMI.value):
           return rog_ally.ryzenadj(tdp)
 
-    fast_tdp = (tdp+2)*1000
     tdp = tdp*1000
 
     if RYZENADJ_PATH:
       commands = [
         RYZENADJ_PATH,
         '--stapm-limit', f"{tdp}",
-        '--fast-limit', f"{fast_tdp}",
+        '--fast-limit', f"{tdp}",
         '--slow-limit', f"{tdp}",
-        '--apu-slow-limit', f"{tdp}"
+        '--tctl-temp', f"95",
+        '--apu-skin-temp', f"95",
+        '--dgpu-skin-temp', f"95",
+        '--max-performance'
       ]
 
       results = subprocess.call(commands)

--- a/py_modules/gpu_utils.py
+++ b/py_modules/gpu_utils.py
@@ -24,12 +24,16 @@ def get_gpu_frequency_range():
       frequency_range = [int(od_sclk_matches[0][0]), int(od_sclk_matches[0][1])]
       GPU_FREQUENCY_RANGE = frequency_range
       return frequency_range
+    else:
+      frequency_range = [-2, -2]
+      GPU_FREQUENCY_RANGE = frequency_range
+      return frequency_range
   except Exception as e:
     decky_plugin.logger.error(e)
 
 def set_gpu_frequency(current_game_id):
   settings = get_saved_settings()
-  gpu_mode = GpuModes.DEFAULT.value
+  gpu_mode = GpuModes.BALANCE.value
   tdp_profile = settings.get("tdpProfiles").get("default")
 
   if settings.get("enableTdpProfiles"):
@@ -41,20 +45,40 @@ def set_gpu_frequency(current_game_id):
 
   # decky_plugin.logger.info(f'{__name__} {current_game_id} {gpu_mode} {tdp_profile}')
 
-  if gpu_mode == GpuModes.DEFAULT.value:
+  if gpu_mode == GpuModes.BALANCE.value:
     try:
       # change back to auto
+      decky_plugin.logger.error(f"{__name__} set balance")
       with open(GPU_LEVEL_PATH,'w') as f:
         f.write("auto")
         f.close()
       return True
     except Exception as e:
-      decky_plugin.logger.error(f"{__name__} default mode error {e}")
+      decky_plugin.logger.error(f"{__name__} balance mode error {e}")
+      return False
+  elif gpu_mode == GpuModes.PERFORMANCE.value:
+    try:
+      decky_plugin.logger.error(f"{__name__} set performance")
+      with open(GPU_LEVEL_PATH,'w') as f:
+        f.write("high")
+        f.close()
+      return True
+    except Exception as e:
+      decky_plugin.logger.error(f"{__name__} performance mode error {e}")
+      return False
+  elif gpu_mode == GpuModes.BATTERY.value:
+    try:
+      decky_plugin.logger.error(f"{__name__} set battery")
+      with open(GPU_LEVEL_PATH,'w') as f:
+        f.write("low")
+        f.close()
+      return True
+    except Exception as e:
+      decky_plugin.logger.error(f"{__name__} power mode error {e}")
       return False
   elif gpu_mode == GpuModes.RANGE.value:
     new_min = tdp_profile.get(GpuRange.MIN.value, 0)
     new_max = tdp_profile.get(GpuRange.MAX.value, 0)
-
     return set_gpu_frequency_range(new_min, new_max)
   elif gpu_mode == GpuModes.FIXED.value:
     new_freq = tdp_profile.get(GpuRange.FIXED.value, 0)
@@ -72,13 +96,25 @@ def set_gpu_frequency_range(new_min: int, new_max: int):
     # decky_plugin.logger.info(f'{min} {max}')
 
     if not (new_min >= min and new_max <= max and new_min <= new_max):
-      # invalid values, just change back to auto
-      # decky_plugin.logger.info(f'auto')
-
-      with open(GPU_LEVEL_PATH,'w') as f:
-        f.write("auto")
-        f.close()
-      return True
+      decky_plugin.logger.info(f'gpu switch')
+      if (new_min == 0 and new_max == 0):
+        decky_plugin.logger.info(f"Set balance mode")
+        with open(GPU_LEVEL_PATH,'w') as f:
+          f.write("auto")
+          f.close()
+        return True
+      elif (new_min == -1 and new_max == 0):
+        decky_plugin.logger.info(f"Set perform mode")
+        with open(GPU_LEVEL_PATH,'w') as f:
+          f.write("high")
+          f.close()
+        return True
+      elif (new_min == -1 and new_max == -1):
+        decky_plugin.logger.info(f"Set power mode")
+        with open(GPU_LEVEL_PATH,'w') as f:
+          f.write("low")
+          f.close()
+        return True
     # decky_plugin.logger.info(f'manual')
 
     with open(GPU_LEVEL_PATH,'w') as file:

--- a/py_modules/plugin_enums.py
+++ b/py_modules/plugin_enums.py
@@ -1,7 +1,9 @@
 from enum import Enum
 
 class GpuModes(Enum):
-  DEFAULT = "DEFAULT"
+  BATTERY = "BATTERY"
+  BALANCE = "BALANCE"
+  PERFORMANCE = "PERFORMANCE"
   RANGE = "RANGE"
   FIXED = "FIXED"
 

--- a/py_modules/plugin_utils.py
+++ b/py_modules/plugin_utils.py
@@ -78,14 +78,14 @@ def set_gpu_for_tdp_profile(tdp_profile):
   if gpu_mode:
     try:
       with file_timeout.time_limit(3):
-        if gpu_mode == 'BALANCE':
+        if gpu_mode == 'BATTERY':
           set_gpu_frequency_range(0, 0)
+          return True
+        elif gpu_mode == 'BALANCE':
+          set_gpu_frequency_range(-1, -1)
           return True
         elif gpu_mode == 'PERFORMANCE':
           set_gpu_frequency_range(-1, 0)
-          return True
-        elif gpu_mode == 'BATTERY':
-          set_gpu_frequency_range(-1, -1)
           return True
         elif gpu_mode == 'FIXED' and fixed_frequency:
           set_gpu_frequency_range(fixed_frequency, fixed_frequency)

--- a/py_modules/plugin_utils.py
+++ b/py_modules/plugin_utils.py
@@ -78,8 +78,14 @@ def set_gpu_for_tdp_profile(tdp_profile):
   if gpu_mode:
     try:
       with file_timeout.time_limit(3):
-        if gpu_mode == 'DEFAULT':
+        if gpu_mode == 'BALANCE':
           set_gpu_frequency_range(0, 0)
+          return True
+        elif gpu_mode == 'PERFORMANCE':
+          set_gpu_frequency_range(-1, 0)
+          return True
+        elif gpu_mode == 'BATTERY':
+          set_gpu_frequency_range(-1, -1)
           return True
         elif gpu_mode == 'FIXED' and fixed_frequency:
           set_gpu_frequency_range(fixed_frequency, fixed_frequency)
@@ -115,7 +121,11 @@ def persist_gpu(minGpuFrequency, maxGpuFrequency, game_id):
   profile_contents = {}
 
   if minGpuFrequency == 0 and maxGpuFrequency == 0:
-    gpu_mode = 'DEFAULT'
+    gpu_mode = 'BATTERY'
+  elif minGpuFrequency == -1 and maxGpuFrequency == -1:
+    gpu_mode = 'BALANCE'
+  elif minGpuFrequency == -1 and maxGpuFrequency == 0:
+    gpu_mode = 'PERFORMANCE'
   elif minGpuFrequency == maxGpuFrequency:
     gpu_mode = 'FIXED'
     profile_contents["fixedGpuFrequency"] = maxGpuFrequency

--- a/py_modules/plugin_utils.py
+++ b/py_modules/plugin_utils.py
@@ -79,10 +79,10 @@ def set_gpu_for_tdp_profile(tdp_profile):
     try:
       with file_timeout.time_limit(3):
         if gpu_mode == 'BATTERY':
-          set_gpu_frequency_range(0, 0)
+          set_gpu_frequency_range(-1, -1)
           return True
         elif gpu_mode == 'BALANCE':
-          set_gpu_frequency_range(-1, -1)
+          set_gpu_frequency_range(0, 0)
           return True
         elif gpu_mode == 'PERFORMANCE':
           set_gpu_frequency_range(-1, 0)
@@ -120,9 +120,9 @@ def persist_gpu(minGpuFrequency, maxGpuFrequency, game_id):
 
   profile_contents = {}
 
-  if minGpuFrequency == 0 and maxGpuFrequency == 0:
+  if minGpuFrequency == -1 and maxGpuFrequency == -1:
     gpu_mode = 'BATTERY'
-  elif minGpuFrequency == -1 and maxGpuFrequency == -1:
+  elif minGpuFrequency == 0 and maxGpuFrequency == 0:
     gpu_mode = 'BALANCE'
   elif minGpuFrequency == -1 and maxGpuFrequency == 0:
     gpu_mode = 'PERFORMANCE'

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -34,7 +34,9 @@ export const DesktopAdvancedOptions = [
 ] as string[];
 
 export enum GpuModes {
-  DEFAULT = "DEFAULT",
+  BATTERY = "BATTERY",
+  BALANCE = "BALANCE",
+  PERFORMANCE = "PERFORMANCE",
   RANGE = "RANGE",
   FIXED = "FIXED",
 }

--- a/src/components/atoms/GpuFixedSlider.tsx
+++ b/src/components/atoms/GpuFixedSlider.tsx
@@ -23,7 +23,7 @@ const GpuFixedSlider = () => {
   const currentFrequency = useSelector(getCurrentFixedGpuFrequencySelector);
   const setFreq = useSetGpuFrequency();
 
-  if (!(min && max) || currentFrequency < '1') {
+  if (!(min && max) || currentFrequency < 1) {
     return <span>Unsupported on this device.</span>;
   }
 

--- a/src/components/atoms/GpuFixedSlider.tsx
+++ b/src/components/atoms/GpuFixedSlider.tsx
@@ -23,7 +23,7 @@ const GpuFixedSlider = () => {
   const currentFrequency = useSelector(getCurrentFixedGpuFrequencySelector);
   const setFreq = useSetGpuFrequency();
 
-  if (!(min && max)) || currentFrequency < '1') {
+  if (!(min && max) || currentFrequency < '1') {
     return <span>Unsupported on this device.</span>;
   }
 

--- a/src/components/atoms/GpuFixedSlider.tsx
+++ b/src/components/atoms/GpuFixedSlider.tsx
@@ -23,8 +23,8 @@ const GpuFixedSlider = () => {
   const currentFrequency = useSelector(getCurrentFixedGpuFrequencySelector);
   const setFreq = useSetGpuFrequency();
 
-  if (!(min && max)) {
-    return <span>Error: Missing GPU Information</span>;
+  if (!(min && max)) || currentFrequency < '1') {
+    return <span>Unsupported on this device.</span>;
   }
 
   return (

--- a/src/components/atoms/GpuModeSlider.tsx
+++ b/src/components/atoms/GpuModeSlider.tsx
@@ -32,7 +32,7 @@ const GpuModeSlider: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
     <>
       <DeckySlider
         label="GPU Mode"
-        value={sliderValue || Mode.BATTERY}
+        value={sliderValue || Mode.BALANCE}
         min={0}
         max={MODES.length - 1}
         step={1}

--- a/src/components/atoms/GpuModeSlider.tsx
+++ b/src/components/atoms/GpuModeSlider.tsx
@@ -4,9 +4,11 @@ import useGpuMode from "../../hooks/useGpuMode";
 import { DeckySlider, NotchLabel } from "./DeckyFrontendLib";
 
 enum Mode {
-  DEFAULT = 0,
-  RANGE = 1,
-  FIXED = 2,
+  BATTERY = 0,
+  BALANCE = 1,
+  PERFORMANCE = 2
+  RANGE = 3,
+  FIXED = 4,
 }
 
 const GpuModeSlider: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
@@ -29,8 +31,8 @@ const GpuModeSlider: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
   return (
     <>
       <DeckySlider
-        label="GPU Frequency Mode"
-        value={sliderValue || Mode.DEFAULT}
+        label="GPU Mode"
+        value={sliderValue || Mode.BATTERY}
         min={0}
         max={MODES.length - 1}
         step={1}

--- a/src/components/atoms/GpuModeSlider.tsx
+++ b/src/components/atoms/GpuModeSlider.tsx
@@ -32,7 +32,7 @@ const GpuModeSlider: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
     <>
       <DeckySlider
         label="GPU Mode"
-        value={sliderValue || Mode.BALANCE}
+        value={sliderValue}
         min={0}
         max={MODES.length - 1}
         step={1}

--- a/src/components/atoms/GpuModeSlider.tsx
+++ b/src/components/atoms/GpuModeSlider.tsx
@@ -22,7 +22,7 @@ const GpuModeSlider: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
   const MODES: NotchLabel[] = Object.keys(Mode)
     .filter((key) => isNaN(Number(key)))
     .map((mode, idx) => {
-      return { notchIndex: idx, label: capitalize(mode), value: idx };
+      return { notchIndex: idx, label: capitalize(mode.slice(0,7) + " " + mode.slice(7)), value: idx };
     });
 
   // known bug: typescript has incorrect type for reverse mapping from enums

--- a/src/components/atoms/GpuModeSlider.tsx
+++ b/src/components/atoms/GpuModeSlider.tsx
@@ -6,7 +6,7 @@ import { DeckySlider, NotchLabel } from "./DeckyFrontendLib";
 enum Mode {
   BATTERY = 0,
   BALANCE = 1,
-  PERFORMANCE = 2
+  PERFORMANCE = 2,
   RANGE = 3,
   FIXED = 4,
 }

--- a/src/components/atoms/GpuRangeSliders.tsx
+++ b/src/components/atoms/GpuRangeSliders.tsx
@@ -28,7 +28,7 @@ const GpuRangeSliders: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
   );
   const { setMinFreq, setMaxFreq } = useSetGpuFrequency();
 
-  if (!(min && max) || currentFrequency < '1') {
+  if (!(min && max) || currentMin < '1') {
     return <span>Unsupported on this device.</span>;
   }
 

--- a/src/components/atoms/GpuRangeSliders.tsx
+++ b/src/components/atoms/GpuRangeSliders.tsx
@@ -28,8 +28,8 @@ const GpuRangeSliders: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
   );
   const { setMinFreq, setMaxFreq } = useSetGpuFrequency();
 
-  if (!(min && max)) {
-    return <span>Error: Missing GPU Information</span>;
+  if (!(min && max) || currentFrequency < '1') {
+    return <span>Unsupported on this device.</span>;
   }
 
   return (

--- a/src/components/atoms/GpuRangeSliders.tsx
+++ b/src/components/atoms/GpuRangeSliders.tsx
@@ -28,7 +28,7 @@ const GpuRangeSliders: FC<{ showSeparator: boolean }> = ({ showSeparator }) => {
   );
   const { setMinFreq, setMaxFreq } = useSetGpuFrequency();
 
-  if (!(min && max) || currentMin < '1') {
+  if (!(min && max) || currentMin < 1) {
     return <span>Unsupported on this device.</span>;
   }
 

--- a/src/components/molecules/Gpu.tsx
+++ b/src/components/molecules/Gpu.tsx
@@ -11,16 +11,11 @@ import { DeckyRow } from "../atoms/DeckyFrontendLib";
 const Gpu = () => {
   const { min, max } = useSelector(getGpuFrequencyRangeSelector);
 
-  // hide GPU section if min/max not available
-  if (!(min && max)) {
-    return null;
-  }
-
   const { gpuMode } = useGpuMode();
   return (
     <ErrorBoundary title="GPU">
       <DeckyRow>
-        <GpuModeSlider showSeparator={gpuMode == GpuModes.DEFAULT} />
+        <GpuModeSlider showSeparator={gpuMode == GpuModes.BALANCE} />
       </DeckyRow>
 
       {gpuMode === GpuModes.RANGE && (

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -94,7 +94,7 @@ const initialState: SettingsState = {
       tdp: DEFAULT_START_TDP,
       cpuBoost: true,
       smt: true,
-      gpuMode: GpuModes.DEFAULT,
+      gpuMode: GpuModes.BALANCE,
       minGpuFrequency: undefined,
       maxGpuFrequency: undefined,
       fixedGpuFrequency: undefined,


### PR DESCRIPTION
We maintain a few changes downstream in SteamFork that could be useful upstream.  This request proposes the following changes:

* Deprecate and remove apu-slow-limit, as it significantly restricts APU performance.  It may be desirable to reintroduce as a separate TDP slider perhaps?
* Modify fast-limit to match the explicit TDP setting as that is the desired state (according to the slider).
* Apply temperature limits to reduce risk of overheating.
* Apply max-performance option to reduce stutter in some games.
* Apply GPU modes from JELOS/SteamFork.
  * Introduce "battery" mode to force the GPU into a low power state.
  * Modify default to balanced (as it is "auto" anyway).
  * Introduce "performance" to force the GPU into the highest performance state.
  * Retains range and fixed frequency modes.
  * Re-orders slider -> Battery / Balanced / Power / Range / Fixed
  * Presents device unsupported message when ranges are not available (legacy APU devices, such as Ayaneo Air and Atari VCS).