### PR TITLE
Drop ryzenadj --max-performance

### DIFF
--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -59,8 +59,7 @@ def ryzenadj(tdp: int):
         '--slow-limit', f"{tdp}",
         '--tctl-temp', f"95",
         '--apu-skin-temp', f"95",
-        '--dgpu-skin-temp', f"95",
-        '--max-performance'
+        '--dgpu-skin-temp', f"95"
       ]
 
       results = subprocess.call(commands)


### PR DESCRIPTION
Testing has proven that there is no measurable benefit of having this setting enabled.  No change to game performance with it enabled or disabled from a clean boot.