### PR TITLE
Enable SMT by default when going into suspend to correct wake issues on multiple devices.

### DIFF
--- a/main.py
+++ b/main.py
@@ -152,9 +152,7 @@ class Plugin:
       plugin_utils.set_power_governor_for_tdp_profile(tdp_profile)
 
   async def on_suspend(self):
-      if device_utils.is_rog_ally():
-        # suspend bug for ROG Ally, force enable smt on_suspend
-        cpu_utils.set_smt(True)
+    cpu_utils.set_smt(True)
 
   async def persist_cpu_boost(self, cpuBoost, gameId):
     tdp_profiles = {


### PR DESCRIPTION
I've been troubleshooting wake issues in SteamFork and I've found that having cores offline when the device wakes from sleep causes a kernel panic on multiple devices.  It looks like SDTDP is already accommodating for that on the Ally but we need it on every device.

I tested this change on an Ayaneo 2S.