### PR TITLE
adding back apu-slow-limit config

### DIFF
--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -102,6 +102,7 @@ def set_amd_tdp(tdp: int):
         '--stapm-limit', f"{tdp}",
         '--fast-limit', f"{tdp}",
         '--slow-limit', f"{tdp}",
+        '--apu-slow-limit', f"{tdp}",
         '--tctl-temp', f"95",
         '--apu-skin-temp', f"95",
         '--dgpu-skin-temp', f"95"


### PR DESCRIPTION
Hi,

Related to this commit: https://github.com/aarron-lee/SimpleDeckyTDP/commit/ddbc69959476421137b67922eab2a7c9b7fbe152, I'd like to propose adding the `--apu-slow-limit` config back into the code. In my case, I'm using a [Minisforum EM780](https://www.minisforum.com/new/support?lang=en#/support/page/download/109) which doesn't have a BIOS configuration for setting this specific value (is set to a fairly low, 28W by default).

I understand that in other scenarios, it may override the current BIOS config (especially the one with the higher value) and set it to a similar value to TDP instead. So we may need to introduce a specific config/slider of this in the future, but at least it should help other users that facing similar issue like me.

PS: I'm currently using my own build to fix this issue, so it's fine for me now!
Thanks!