### PR TITLE
add advanced option toggle for ryzenadj apu-slow-limit

### DIFF
--- a/py_modules/advanced_options.py
+++ b/py_modules/advanced_options.py
@@ -15,6 +15,7 @@ PLATFORM_PROFILE_PATH = '/sys/firmware/acpi/platform_profile'
 class DefaultSettings(Enum):
   ENABLE_TDP_CONTROL = 'enableTdpControl'
   ENABLE_GPU_CONTROL = 'enableGpuControl'
+  ENABLE_APU_SLOW_LIMIT = 'enableApuSlowLimit'
   ENABLE_STEAM_PATCH = 'steamPatch'
   ENABLE_POWER_CONTROL = 'enablePowercontrol'
   ENABLE_BACKGROUND_POLLING = 'enableBackgroundPolling'
@@ -174,6 +175,19 @@ def get_default_options():
   }
 
   options.append(max_tdp_on_resume)
+
+  if not device_utils.is_intel():
+    # enable apu-slow-limit control
+    enable_apu_slow_limit = {
+      'name': 'Enable APU Slow Limit',
+      'type': 'boolean',
+      'defaultValue': False,
+      'description': 'Enables the --apu-slow-limit value for ryzenadj',
+      'currentValue': get_value(DefaultSettings.ENABLE_APU_SLOW_LIMIT, False),
+      'statePath': DefaultSettings.ENABLE_APU_SLOW_LIMIT.value
+    }
+
+    options.append(enable_apu_slow_limit)
 
   return options
 

--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -107,6 +107,14 @@ def set_amd_tdp(tdp: int):
         '--dgpu-skin-temp', f"95"
       ]
 
+      if advanced_options.get_setting(
+        advanced_options.DefaultSettings.ENABLE_APU_SLOW_LIMIT.value
+      ):
+        commands.append('--apu-slow-limit')
+        commands.append(f"{tdp}")
+
+      decky_plugin.logger.info(f'setting TDP via ryzenadj with args {commands}')
+
       results = subprocess.call(commands)
       return results
   except Exception as e:

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -4,6 +4,7 @@ import { IS_DESKTOP } from "../components/atoms/DeckyFrontendLib";
 export enum AdvancedOptionsEnum {
   ENABLE_TDP_CONTROL = "enableTdpControl",
   ENABLE_GPU_CONTROL = "enableGpuControl",
+  ENABLE_APU_SLOW_LIMIT = "enableApuSlowLimit",
   STEAM_PATCH = "steamPatch",
   ENABLE_POWER_CONTROL = "enablePowercontrol",
   ENABLE_BACKGROUND_POLLING = "enableBackgroundPolling",


### PR DESCRIPTION
should address #49 

requires some testing

build for manual testing here: 
[SimpleDeckyTDP.tar.gz](https://github.com/user-attachments/files/17983440/SimpleDeckyTDP.tar.gz)
