### PR TITLE
Bug fix EppSlider Array Index Mismatch

### DIFF
--- a/src/components/atoms/EppSlider.tsx
+++ b/src/components/atoms/EppSlider.tsx
@@ -21,8 +21,8 @@ const getOptions = (eppOptions: EppOption[]) => {
   let notchIdx = 0;
   eppOptions.forEach((option, idx) => {
     if (EppOptions[option]) {
-      idxToOption[idx] = option;
-      optionToIdx[option] = idx;
+      idxToOption[notchIdx] = option;
+      optionToIdx[option] = notchIdx;
 
       const label = EppOptions[option];
       notchLabels.push({


### PR DESCRIPTION
https://github.com/aarron-lee/SimpleDeckyTDP/issues/59 The array index was not matching the values displayed in the slider. This happens because the Steam Deck has more 'eppOptions' than the ones in the 'EppOption' constant.


Please, if possible, test this change on another device different from the Steam Deck to make sure it doesn't break any of the current functionality.

Feel free to modify the code. I don't know much about TypeScript, so maybe the modification doesn't follow "clean code" principles.