### PR TITLE
Add support for Steam Deck Custom TDP and GPU values

### DIFF
--- a/check.sh
+++ b/check.sh
@@ -1,0 +1,7 @@
+ #!/bin/bash
+
+sudo ryzenadj -i
+cat /sys/class/drm/card?/device/pp_od_clk_voltage
+cat /sys/devices/system/cpu/cpufreq/policy*/boost
+cat /sys/devices/system/cpu/smt/control
+cat /sys/devices/system/cpu/cpu*/cpufreq/energy_performance_preference

--- a/main.py
+++ b/main.py
@@ -152,6 +152,8 @@ class Plugin:
       cpu_utils.set_smt(smt)
       time.sleep(0.3)
       plugin_utils.set_power_governor_for_tdp_profile(tdp_profile)
+      plugin_utils.set_cpu_boost_for_tdp_profile(tdp_profile)
+
 
   async def on_suspend(self):
     decky_plugin.logger.info(f'main#on_suspend started')

--- a/py_modules/advanced_options.py
+++ b/py_modules/advanced_options.py
@@ -348,7 +348,7 @@ def steam_deck_advanced_options(options):
     'range': [1600, 2200],
     'defaultValue': 1600,
     'step': 50,
-    'valueSuffix': '',
+    'valueSuffix': 'MHz',
     'description': 'Requires Custom Bios',
     'currentValue': get_number_value(SteamDeckSettings.DECK_CUSTOM_GPU_MAX, 1600),
     'statePath': SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value,

--- a/py_modules/advanced_options.py
+++ b/py_modules/advanced_options.py
@@ -14,7 +14,6 @@ class AdvancedOptionsType(Enum):
   BOOLEAN = 'boolean'
   NUMBER_RANGE = 'number_range'
 
-
 class DefaultSettings(Enum):
   ENABLE_TDP_CONTROL = 'enableTdpControl'
   ENABLE_GPU_CONTROL = 'enableGpuControl'
@@ -41,6 +40,8 @@ class LegionGoSettings(Enum):
 
 class SteamDeckSettings(Enum):
   DECK_CUSTOM_TDP_LIMITS = 'deckCustomTdpLimits'
+  DECK_CUSTOM_GPU_MAX_ENABLED = 'deckCustomGpuMaxEnabled'
+  DECK_CUSTOM_GPU_MAX = 'deckCustomGpuMax'
 
 def modprobe_acpi_call():
   # legion go currently requires acpi_call for using WMI to set TDP
@@ -316,7 +317,7 @@ def steam_deck_advanced_options(options):
   options.append({
     'name': 'Enable TDP slider min/max adjustment',
     'type': AdvancedOptionsType.BOOLEAN.value,
-    'description': 'Warning, this probably needs a custom bios',
+    'description': 'Warning, this needs a custom bios on the Steam Deck',
     'defaultValue': False,
     'currentValue': get_value(SteamDeckSettings.DECK_CUSTOM_TDP_LIMITS, False),
     'statePath': SteamDeckSettings.DECK_CUSTOM_TDP_LIMITS.value,
@@ -325,6 +326,39 @@ def steam_deck_advanced_options(options):
       "hideIfDisabled": True
     }
   })
+
+  enable_deck_custom_gpu_clock = {
+    'name': 'Enable custom GPU Max Clock',
+    'type': AdvancedOptionsType.BOOLEAN.value,
+    'defaultValue': False,
+    'description': 'Warning, this needs a custom bios on the Steam Deck',
+    'currentValue': get_value(SteamDeckSettings.DECK_CUSTOM_GPU_MAX_ENABLED, False),
+    'statePath': SteamDeckSettings.DECK_CUSTOM_GPU_MAX_ENABLED.value,
+    'disabled': {
+      'ifFalsy': [DefaultSettings.ENABLE_GPU_CONTROL.value],
+      'hideIfDisabled': True
+    }
+  }
+
+  options.append(enable_deck_custom_gpu_clock)
+
+  custom_gpu_clock = {
+    'name': 'Custom GPU Max Clock',
+    'type': AdvancedOptionsType.NUMBER_RANGE.value,
+    'range': [1600, 2200],
+    'defaultValue': 1600,
+    'step': 50,
+    'valueSuffix': '',
+    'description': 'Requires Custom Bios',
+    'currentValue': get_number_value(SteamDeckSettings.DECK_CUSTOM_GPU_MAX, 1600),
+    'statePath': SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value,
+    'disabled': {
+      'ifFalsy': [SteamDeckSettings.DECK_CUSTOM_GPU_MAX_ENABLED.value],
+      'hideIfDisabled': True
+    }
+  }
+
+  options.append(custom_gpu_clock)
 
 def rog_ally_advanced_options(options):
   if os.path.exists(PLATFORM_PROFILE_PATH):

--- a/py_modules/gpu_utils.py
+++ b/py_modules/gpu_utils.py
@@ -209,11 +209,12 @@ def get_deck_gpu_range():
     )
 
     if custom_max_enabled:
-      custom_max = advanced_options.get_setting(
-        advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value
-      )
+        custom_max = advanced_options.get_setting(
+          advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value
+        )
 
-      return [200, custom_max or 1600]
+        if isinstance(custom_max, int):
+            return [200, custom_max or 1600]
 
     return GPU_FREQUENCY_RANGE
 

--- a/py_modules/gpu_utils.py
+++ b/py_modules/gpu_utils.py
@@ -29,9 +29,7 @@ def get_gpu_frequency_range():
   else:
     try:
       if device_utils.is_steam_deck():
-        # Steam Deck pp_od_clk_voltage is empty, so min/max values can't be automatically detected
-        GPU_FREQUENCY_RANGE = [200, 1600]
-        return GPU_FREQUENCY_RANGE
+        return get_deck_gpu_range()
 
       freq_string = open(GPU_FREQUENCY_PATH,"r").read()
       od_sclk_matches = re.findall(r"OD_RANGE:\s*SCLK:\s*(\d+)Mhz\s*(\d+)Mhz", freq_string)
@@ -202,6 +200,22 @@ def get_intel_gpu_clocks():
         decky_plugin.logger.error('error while getting intel gpu clocks')
         return [None, None]
 
+def get_deck_gpu_range():
+    # Steam Deck pp_od_clk_voltage is empty, so min/max values can't be automatically detected
+    GPU_FREQUENCY_RANGE = [200, 1600]
+
+    custom_max_enabled = advanced_options.get_setting(
+      advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX_ENABLED.value
+    )
+
+    if custom_max_enabled:
+      custom_max = advanced_options.get_setting(
+        advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value
+      )
+
+      return [200, custom_max or 1600]
+
+    return GPU_FREQUENCY_RANGE
 
 def execute_gpu_frequency_command(command):
   cmd = f"echo '{command}' | tee {GPU_FREQUENCY_PATH}"

--- a/py_modules/gpu_utils.py
+++ b/py_modules/gpu_utils.py
@@ -141,82 +141,82 @@ def set_gpu_frequency_range(new_min: int, new_max: int):
     return set_amd_gpu_frequency_range(new_min, new_max)
 
 def set_amd_gpu_frequency_range(new_min, new_max):
+  try:
+    min, max = get_gpu_frequency_range()
+
+    # decky_plugin.logger.info(f'{new_min} {new_max}')
+    # decky_plugin.logger.info(f'{min} {max}')
+
+    if not (new_min >= min and new_max <= max and new_min <= new_max):
+      if (new_min == 0 and new_max == 0):
+        decky_plugin.logger.info(f"{__name__} Set GPU balance mode")
+        with open(GPU_LEVEL_PATH,'w') as f:
+          f.write("auto")
+          f.close()
+        return True
+      elif (new_min == -1 and new_max == 0):
+        decky_plugin.logger.info(f"{__name__} Set GPU perform mode")
+        with open(GPU_LEVEL_PATH,'w') as f:
+          f.write("high")
+          f.close()
+        return True
+      elif (new_min == -1 and new_max == -1):
+        decky_plugin.logger.info(f"{__name__} Set GPU power mode")
+        with open(GPU_LEVEL_PATH,'w') as f:
+          f.write("low")
+          f.close()
+        return True
+    # decky_plugin.logger.info(f'manual')
+
+    with open(GPU_LEVEL_PATH,'w') as file:
+      file.write("manual")
+      file.close()
+    time.sleep(0.1)
     try:
-      min, max = get_gpu_frequency_range()
-
-      # decky_plugin.logger.info(f'{new_min} {new_max}')
-      # decky_plugin.logger.info(f'{min} {max}')
-
-      if not (new_min >= min and new_max <= max and new_min <= new_max):
-        if (new_min == 0 and new_max == 0):
-          decky_plugin.logger.info(f"{__name__} Set GPU balance mode")
-          with open(GPU_LEVEL_PATH,'w') as f:
-            f.write("auto")
-            f.close()
-          return True
-        elif (new_min == -1 and new_max == 0):
-          decky_plugin.logger.info(f"{__name__} Set GPU perform mode")
-          with open(GPU_LEVEL_PATH,'w') as f:
-            f.write("high")
-            f.close()
-          return True
-        elif (new_min == -1 and new_max == -1):
-          decky_plugin.logger.info(f"{__name__} Set GPU power mode")
-          with open(GPU_LEVEL_PATH,'w') as f:
-            f.write("low")
-            f.close()
-          return True
-      # decky_plugin.logger.info(f'manual')
-
-      with open(GPU_LEVEL_PATH,'w') as file:
-        file.write("manual")
-        file.close()
-      time.sleep(0.1)
-      try:
-        decky_plugin.logger.info(f"{__name__} Set GPU freq range {new_min} {new_max}")
-        execute_gpu_frequency_command(f"s 0 {new_min}")
-        execute_gpu_frequency_command(f"s 1 {new_max}")
-        execute_gpu_frequency_command("c")
-      except Exception as e:
-        decky_plugin.logger.error(f"{__name__} error while trying to write frequency range {e} {new_min} {new_max}")
-
-      return True
+      decky_plugin.logger.info(f"{__name__} Set GPU freq range {new_min} {new_max}")
+      execute_gpu_frequency_command(f"s 0 {new_min}")
+      execute_gpu_frequency_command(f"s 1 {new_max}")
+      execute_gpu_frequency_command("c")
     except Exception as e:
-      decky_plugin.logger.error(f"set_gpu_frequency_range {new_min} {new_max} error {e}")
-      return False
+      decky_plugin.logger.error(f"{__name__} error while trying to write frequency range {e} {new_min} {new_max}")
+
+    return True
+  except Exception as e:
+    decky_plugin.logger.error(f"set_gpu_frequency_range {new_min} {new_max} error {e}")
+    return False
 
 def get_intel_gpu_clocks():
-    try:
-        max_cmd = 'cat /sys/class/drm/card?/gt_max_freq_mhz'
-        max_result = subprocess.run(max_cmd, shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        max_gpu_clock = int(max_result.stdout.strip())
+  try:
+    max_cmd = 'cat /sys/class/drm/card?/gt_max_freq_mhz'
+    max_result = subprocess.run(max_cmd, shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    max_gpu_clock = int(max_result.stdout.strip())
 
-        min_cmd = 'cat /sys/class/drm/card?/gt_min_freq_mhz'
-        min_result = subprocess.run(min_cmd, shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
-        min_gpu_clock = int(min_result.stdout.strip())
+    min_cmd = 'cat /sys/class/drm/card?/gt_min_freq_mhz'
+    min_result = subprocess.run(min_cmd, shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE)
+    min_gpu_clock = int(min_result.stdout.strip())
 
-        return [min_gpu_clock, max_gpu_clock]
-    except Exception as e:
-        decky_plugin.logger.error('error while getting intel gpu clocks')
-        return [None, None]
+    return [min_gpu_clock, max_gpu_clock]
+  except Exception as e:
+    decky_plugin.logger.error('error while getting intel gpu clocks')
+    return [None, None]
 
 def get_deck_gpu_range():
-    # Steam Deck pp_od_clk_voltage is empty, so min/max values can't be automatically detected
-    GPU_FREQUENCY_RANGE = [200, 1600]
+  # Steam Deck pp_od_clk_voltage is empty, so min/max values can't be automatically detected
+  GPU_FREQUENCY_RANGE = [200, 1600]
 
-    custom_max_enabled = advanced_options.get_setting(
-      advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX_ENABLED.value
+  custom_max_enabled = advanced_options.get_setting(
+    advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX_ENABLED.value
+  )
+
+  if custom_max_enabled:
+    custom_max = advanced_options.get_setting(
+      advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value
     )
 
-    if custom_max_enabled:
-        custom_max = advanced_options.get_setting(
-          advanced_options.SteamDeckSettings.DECK_CUSTOM_GPU_MAX.value
-        )
+    if isinstance(custom_max, int):
+      return [200, custom_max or 1600]
 
-        if isinstance(custom_max, int):
-            return [200, custom_max or 1600]
-
-    return GPU_FREQUENCY_RANGE
+  return GPU_FREQUENCY_RANGE
 
 def execute_gpu_frequency_command(command):
   cmd = f"echo '{command}' | tee {GPU_FREQUENCY_PATH}"

--- a/py_modules/plugin_utils.py
+++ b/py_modules/plugin_utils.py
@@ -33,8 +33,8 @@ def set_values_for_tdp_profile(tdp_profile, set_tdp = True, set_gpu = True, set_
   if not manual_cpu_management_enabled and not automatic_cpu_management_enabled:
     return
 
-  set_cpu_boost_for_tdp_profile(profile)
   set_smt_for_tdp_profile(profile)
+  set_cpu_boost_for_tdp_profile(profile)
 
   # if user has manual CPU controls disabled, use default CPU profile instead
   if not manual_cpu_management_enabled:

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -124,6 +124,11 @@ export const setMaxTdp = callable(ServerAPIMethods.SET_MAX_TDP);
 export const isSteamRunning = callable(ServerAPIMethods.GET_IS_STEAM_RUNNING);
 
 export const logInfo = ({ info }: { info: any }) => {
+  if (info instanceof Error) {
+    const errorInfo = JSON.stringify(info, Object.getOwnPropertyNames(info));
+    return call(ServerAPIMethods.LOG_INFO, { info: errorInfo });
+  }
+
   return call(ServerAPIMethods.LOG_INFO, { info });
 };
 

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -49,6 +49,8 @@ export enum LegionGoAdvancedOptions {
 
 export enum SteamDeckAdvancedOptions {
   DECK_CUSTOM_TDP_LIMITS = "deckCustomTdpLimits",
+  DECK_CUSTOM_GPU_MAX_ENABLED = "deckCustomGpuMaxEnabled",
+  DECK_CUSTOM_GPU_MAX = "deckCustomGpuMax",
 }
 
 export const DesktopAdvancedOptions = [

--- a/src/components/molecules/AdvancedOptions.tsx
+++ b/src/components/molecules/AdvancedOptions.tsx
@@ -23,6 +23,7 @@ import {
   AdvancedOptionsType,
   DesktopAdvancedOptions,
 } from "../../backend/utils";
+import useDeviceName from "../../hooks/useDeviceName";
 
 export const useIsSteamPatchEnabled = () => {
   const steamPatchEnabled = useSelector(getSteamPatchEnabledSelector);
@@ -65,6 +66,7 @@ const calculateDisabled = (
 
 const AdvancedOptions = () => {
   const dispatch = useDispatch<AppDispatch>();
+  const deviceName = useDeviceName();
   const isDesktop = useIsDesktop();
   const { advancedState, advancedOptions } = useSelector(
     getAdvancedOptionsInfoSelector
@@ -122,7 +124,11 @@ const AdvancedOptions = () => {
                     bottomSeparator="none"
                     onChange={(enabled: boolean) => {
                       return dispatch(
-                        updateAdvancedOption({ statePath, value: enabled })
+                        updateAdvancedOption({
+                          statePath,
+                          value: enabled,
+                          deviceName,
+                        })
                       );
                     }}
                     disabled={disabled}
@@ -164,7 +170,11 @@ const AdvancedOptions = () => {
                     description={showDescription ? description : undefined}
                     onChange={(newValue: number) => {
                       return dispatch(
-                        updateAdvancedOption({ statePath, value: newValue })
+                        updateAdvancedOption({
+                          statePath,
+                          value: newValue,
+                          deviceName,
+                        })
                       );
                     }}
                     valueSuffix={valueSuffix}

--- a/src/components/molecules/OtaUpdates.tsx
+++ b/src/components/molecules/OtaUpdates.tsx
@@ -2,16 +2,14 @@ import { useEffect, useState } from "react";
 import { getLatestVersionNum, otaUpdate } from "../../backend/utils";
 import { useSelector } from "react-redux";
 import { getInstalledVersionNumSelector } from "../../redux-modules/settingsSlice";
-import {
-  selectDeviceName,
-  selectScalingDriver,
-} from "../../redux-modules/uiSlice";
+import { selectScalingDriver } from "../../redux-modules/uiSlice";
 import {
   DeckyButton,
   DeckyField,
   DeckyRow,
   DeckySection,
 } from "../atoms/DeckyFrontendLib";
+import { selectDeviceName } from "../../utils/selectors";
 
 const OtaUpdates = () => {
   const [latestVersionNum, setLatestVersionNum] = useState("");

--- a/src/components/molecules/OtaUpdates.tsx
+++ b/src/components/molecules/OtaUpdates.tsx
@@ -9,7 +9,7 @@ import {
   DeckyRow,
   DeckySection,
 } from "../atoms/DeckyFrontendLib";
-import { selectDeviceName } from "../../utils/selectors";
+import useDeviceName from "../../hooks/useDeviceName";
 
 const OtaUpdates = () => {
   const [latestVersionNum, setLatestVersionNum] = useState("");
@@ -17,7 +17,7 @@ const OtaUpdates = () => {
 
   const installedVersionNum = useSelector(getInstalledVersionNumSelector);
   const scalingDriver = useSelector(selectScalingDriver);
-  const deviceName = useSelector(selectDeviceName);
+  const deviceName = useDeviceName();
 
   const isUpdated =
     installedVersionNum === latestVersionNum && Boolean(latestVersionNum);

--- a/src/components/molecules/TdpRange.tsx
+++ b/src/components/molecules/TdpRange.tsx
@@ -11,14 +11,15 @@ import { useDeviceName, useIsSteamDeck } from "../../hooks/useDeviceName";
 import { Devices, SteamDeckAdvancedOptions } from "../../backend/utils";
 import { useAdvancedOption } from "../../hooks/useAdvanced";
 
-const useMaxSupportedTdpValue = ({ isSteamDeck }: { isSteamDeck: boolean }) => {
+const useMaxSupportedTdpValue = () => {
   let maxTdp = 40;
+
+  const deviceName = useDeviceName();
+  const isSteamDeck = useIsSteamDeck();
 
   if (isSteamDeck) {
     return 20;
   }
-
-  const deviceName = useDeviceName();
 
   if (
     deviceName.includes(Devices.ASUS_FLOW_Z13) ||
@@ -40,7 +41,7 @@ const TdpRange = () => {
     SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS
   );
   const isIntel = useIsIntel();
-  let maxSupportedTdpValue = useMaxSupportedTdpValue({ isSteamDeck });
+  const maxSupportedTdpValue = useMaxSupportedTdpValue();
 
   if (isIntel) {
     // intel provides TDP limit values, custom TDP range is unnecessary

--- a/src/components/molecules/TdpRange.tsx
+++ b/src/components/molecules/TdpRange.tsx
@@ -11,8 +11,12 @@ import { useDeviceName, useIsSteamDeck } from "../../hooks/useDeviceName";
 import { Devices, SteamDeckAdvancedOptions } from "../../backend/utils";
 import { useAdvancedOption } from "../../hooks/useAdvanced";
 
-const useMaxSupportedTdpValue = () => {
+const useMaxSupportedTdpValue = ({ isSteamDeck }: { isSteamDeck: boolean }) => {
   let maxTdp = 40;
+
+  if (isSteamDeck) {
+    return 20;
+  }
 
   const deviceName = useDeviceName();
 
@@ -36,7 +40,7 @@ const TdpRange = () => {
     SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS
   );
   const isIntel = useIsIntel();
-  const maxSupportedTdpValue = useMaxSupportedTdpValue();
+  let maxSupportedTdpValue = useMaxSupportedTdpValue({ isSteamDeck });
 
   if (isIntel) {
     // intel provides TDP limit values, custom TDP range is unnecessary

--- a/src/hooks/useDeviceName.tsx
+++ b/src/hooks/useDeviceName.tsx
@@ -1,5 +1,5 @@
 import { useSelector } from "react-redux";
-import { selectDeviceName, selectIsSteamDeck } from "../redux-modules/uiSlice";
+import { selectDeviceName, selectIsSteamDeck } from "../utils/selectors";
 
 export const useDeviceName = () => {
   return useSelector(selectDeviceName);

--- a/src/hooks/useDeviceName.tsx
+++ b/src/hooks/useDeviceName.tsx
@@ -1,22 +1,14 @@
 import { useSelector } from "react-redux";
-
-import { selectDeviceName } from "../redux-modules/uiSlice";
-import { Devices } from "../backend/utils";
+import { selectDeviceName, selectIsSteamDeck } from "../redux-modules/uiSlice";
 
 export const useDeviceName = () => {
   return useSelector(selectDeviceName);
 };
 
 export const useIsSteamDeck = () => {
-  const deviceName = useSelector(selectDeviceName);
+  const isSteamDeck = useSelector(selectIsSteamDeck);
 
-  if (
-    deviceName.includes(Devices.STEAM_DECK_LCD) ||
-    deviceName.includes(Devices.STEAM_DECK_OLED)
-  ) {
-    return true;
-  }
-  return false;
+  return isSteamDeck;
 };
 
 export default useDeviceName;

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -626,29 +626,52 @@ function handleSteamDeckAdvancedOptions(
 ) {
   const isSteamDeck = selectIsSteamDeck(state);
 
-  if (
-    isSteamDeck &&
-    statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
-    Boolean(value) == true
-  ) {
-    // polling must be forced on when using custom TDP limits on deck
-    set(
-      state,
-      `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
-      true
-    );
-  }
-  if (
-    isSteamDeck &&
-    statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
-    Boolean(value) == false
-  ) {
-    set(
-      state,
-      `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
-      false
-    );
-  }
+  if (isSteamDeck) {
+    if (
+      statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
+      Boolean(value) == true
+    ) {
+      // polling must be forced on when using custom TDP limits on deck
+      set(
+        state,
+        `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
+        true
+      );
+    }
+    if (
+      statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
+      Boolean(value) == false
+    ) {
+      set(
+        state,
+        `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
+        false
+      );
+    }
+
+    if (
+      statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED &&
+      Boolean(value) == false
+    ) {
+      // force maxGpuFrequency back to 1600 max for Steam Deck
+      state.settings.maxGpuFrequency = 1600;
+    } else {
+      const customGpuLimitEnabled = get(
+        state,
+        `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED}`,
+        false
+      );
+
+      if (customGpuLimitEnabled) {
+        if (
+          statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX &&
+          value
+        ) {
+          state.settings.maxGpuFrequency = value;
+        }
+      }
+    }
+  } // end ifSteamDeck
 }
 
 // Action creators are generated for each case reducer function

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -16,7 +16,7 @@ import {
   GpuModes,
   SteamDeckAdvancedOptions,
 } from "../backend/utils";
-import { selectIsSteamDeck } from "./uiSlice";
+import { selectIsSteamDeck } from "../utils/selectors";
 
 type Partial<T> = {
   [P in keyof T]?: T[P];

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -10,7 +10,7 @@ import {
   PowerControlsType,
   PowerGovernorOption,
 } from "../utils/constants";
-import { RootState } from "./store";
+import { RootState, store } from "./store";
 import {
   AdvancedOptionsEnum,
   GpuModes,
@@ -586,40 +586,45 @@ function handleAdvancedOptionsEdgeCases(
 ) {
   try {
     handleSteamDeckAdvancedOptions(state, statePath, value);
+
+    if (statePath === AdvancedOptionsEnum.USE_PLATFORM_PROFILE && value) {
+      set(
+        state,
+        `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
+        false
+      );
+    }
+    if (statePath === AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING && value) {
+      if (typeof state?.advanced?.platformProfile === "boolean") {
+        set(
+          state,
+          `advanced.${AdvancedOptionsEnum.USE_PLATFORM_PROFILE}`,
+          false
+        );
+      }
+    }
+    if (statePath === AdvancedOptionsEnum.AC_POWER_PROFILES) {
+      set(state, `advanced.${AdvancedOptionsEnum.STEAM_PATCH}`, false);
+    }
+    if (statePath === AdvancedOptionsEnum.STEAM_PATCH) {
+      set(state, `advanced.${AdvancedOptionsEnum.AC_POWER_PROFILES}`, false);
+    }
+    if (
+      statePath === AdvancedOptionsEnum.FORCE_DISABLE_TDP_ON_RESUME &&
+      value === true
+    ) {
+      set(state, `advanced.${AdvancedOptionsEnum.MAX_TDP_ON_RESUME}`, false);
+    }
+
+    if (statePath === AdvancedOptionsEnum.MAX_TDP_ON_RESUME && value === true) {
+      set(
+        state,
+        `advanced.${AdvancedOptionsEnum.FORCE_DISABLE_TDP_ON_RESUME}`,
+        false
+      );
+    }
   } catch (err) {
     logInfo({ info: err });
-  }
-  if (statePath === AdvancedOptionsEnum.USE_PLATFORM_PROFILE && value) {
-    set(
-      state,
-      `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
-      false
-    );
-  }
-  if (statePath === AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING && value) {
-    if (typeof state?.advanced?.platformProfile === "boolean") {
-      set(state, `advanced.${AdvancedOptionsEnum.USE_PLATFORM_PROFILE}`, false);
-    }
-  }
-  if (statePath === AdvancedOptionsEnum.AC_POWER_PROFILES) {
-    set(state, `advanced.${AdvancedOptionsEnum.STEAM_PATCH}`, false);
-  }
-  if (statePath === AdvancedOptionsEnum.STEAM_PATCH) {
-    set(state, `advanced.${AdvancedOptionsEnum.AC_POWER_PROFILES}`, false);
-  }
-  if (
-    statePath === AdvancedOptionsEnum.FORCE_DISABLE_TDP_ON_RESUME &&
-    value === true
-  ) {
-    set(state, `advanced.${AdvancedOptionsEnum.MAX_TDP_ON_RESUME}`, false);
-  }
-
-  if (statePath === AdvancedOptionsEnum.MAX_TDP_ON_RESUME && value === true) {
-    set(
-      state,
-      `advanced.${AdvancedOptionsEnum.FORCE_DISABLE_TDP_ON_RESUME}`,
-      false
-    );
   }
 }
 
@@ -628,7 +633,7 @@ function handleSteamDeckAdvancedOptions(
   statePath: string,
   value: boolean
 ) {
-  const isSteamDeck = selectIsSteamDeck(state);
+  const isSteamDeck = selectIsSteamDeck(store.getState());
 
   const disableCustomGpuLimit = () => {
     set(

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -648,6 +648,22 @@ function handleSteamDeckAdvancedOptions(
         false
       );
     }
+    if (
+      statePath == AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING &&
+      Boolean(value) == false
+    ) {
+      // turn off custom TDP and GPU limits if background polling turned off
+      set(
+        state,
+        `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS}`,
+        false
+      );
+      set(
+        state,
+        `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED}`,
+        false
+      );
+    }
 
     if (
       statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED &&
@@ -669,6 +685,9 @@ function handleSteamDeckAdvancedOptions(
         ) {
           state.settings.maxGpuFrequency = value;
         }
+      } else {
+        // force maxGpuFrequency back to 1600 max for Steam Deck
+        state.settings.maxGpuFrequency = 1600;
       }
     }
   } // end ifSteamDeck

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -11,7 +11,12 @@ import {
   PowerGovernorOption,
 } from "../utils/constants";
 import { RootState } from "./store";
-import { AdvancedOptionsEnum, GpuModes } from "../backend/utils";
+import {
+  AdvancedOptionsEnum,
+  GpuModes,
+  SteamDeckAdvancedOptions,
+} from "../backend/utils";
+import { selectIsSteamDeck } from "./uiSlice";
 
 type Partial<T> = {
   [P in keyof T]?: T[P];
@@ -578,6 +583,8 @@ function handleAdvancedOptionsEdgeCases(
   statePath: string,
   value: boolean
 ) {
+  handleSteamDeckAdvancedOptions(state, statePath, value);
+
   if (statePath === AdvancedOptionsEnum.USE_PLATFORM_PROFILE && value) {
     set(
       state,
@@ -607,6 +614,38 @@ function handleAdvancedOptionsEdgeCases(
     set(
       state,
       `advanced.${AdvancedOptionsEnum.FORCE_DISABLE_TDP_ON_RESUME}`,
+      false
+    );
+  }
+}
+
+function handleSteamDeckAdvancedOptions(
+  state: any,
+  statePath: string,
+  value: boolean
+) {
+  const isSteamDeck = selectIsSteamDeck(state);
+
+  if (
+    isSteamDeck &&
+    statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
+    Boolean(value) == true
+  ) {
+    // polling must be forced on when using custom TDP limits on deck
+    set(
+      state,
+      `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
+      true
+    );
+  }
+  if (
+    isSteamDeck &&
+    statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
+    Boolean(value) == false
+  ) {
+    set(
+      state,
+      `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
       false
     );
   }

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -650,17 +650,6 @@ function handleSteamDeckAdvancedOptions(
       );
     }
     if (
-      (statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS ||
-        statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED) &&
-      Boolean(value) == false
-    ) {
-      set(
-        state,
-        `advanced.${AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING}`,
-        false
-      );
-    }
-    if (
       statePath == AdvancedOptionsEnum.ENABLE_BACKGROUND_POLLING &&
       Boolean(value) == false
     ) {

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -14,6 +14,7 @@ import { RootState } from "./store";
 import {
   AdvancedOptionsEnum,
   GpuModes,
+  logInfo,
   SteamDeckAdvancedOptions,
 } from "../backend/utils";
 import { selectIsSteamDeck } from "../utils/selectors";
@@ -583,8 +584,11 @@ function handleAdvancedOptionsEdgeCases(
   statePath: string,
   value: boolean
 ) {
-  handleSteamDeckAdvancedOptions(state, statePath, value);
-
+  try {
+    handleSteamDeckAdvancedOptions(state, statePath, value);
+  } catch (err) {
+    logInfo({ info: JSON.stringify(err, Object.getOwnPropertyNames(err)) });
+  }
   if (statePath === AdvancedOptionsEnum.USE_PLATFORM_PROFILE && value) {
     set(
       state,

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -626,9 +626,20 @@ function handleSteamDeckAdvancedOptions(
 ) {
   const isSteamDeck = selectIsSteamDeck(state);
 
+  const disableCustomGpuLimit = () => {
+    set(
+      state,
+      `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED}`,
+      false
+    );
+    // force maxGpuFrequency back to 1600 max for Steam Deck
+    state.settings.maxGpuFrequency = 1600;
+  };
+
   if (isSteamDeck) {
     if (
-      statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
+      (statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS ||
+        statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED) &&
       Boolean(value) == true
     ) {
       // polling must be forced on when using custom TDP limits on deck
@@ -639,7 +650,8 @@ function handleSteamDeckAdvancedOptions(
       );
     }
     if (
-      statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS &&
+      (statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS ||
+        statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED) &&
       Boolean(value) == false
     ) {
       set(
@@ -658,19 +670,14 @@ function handleSteamDeckAdvancedOptions(
         `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_TDP_LIMITS}`,
         false
       );
-      set(
-        state,
-        `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED}`,
-        false
-      );
+      disableCustomGpuLimit();
     }
 
     if (
       statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED &&
       Boolean(value) == false
     ) {
-      // force maxGpuFrequency back to 1600 max for Steam Deck
-      state.settings.maxGpuFrequency = 1600;
+      disableCustomGpuLimit();
     } else {
       const customGpuLimitEnabled = get(
         state,
@@ -681,13 +688,12 @@ function handleSteamDeckAdvancedOptions(
       if (customGpuLimitEnabled) {
         if (
           statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX &&
-          value
+          Number(value) >= 1600
         ) {
           state.settings.maxGpuFrequency = value;
         }
       } else {
-        // force maxGpuFrequency back to 1600 max for Steam Deck
-        state.settings.maxGpuFrequency = 1600;
+        disableCustomGpuLimit();
       }
     }
   } // end ifSteamDeck

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -633,7 +633,7 @@ function handleSteamDeckAdvancedOptions(
       false
     );
     // force maxGpuFrequency back to 1600 max for Steam Deck
-    state.settings.maxGpuFrequency = 1600;
+    set(state, "settings.maxGpuFrequency", 1600);
   };
 
   if (isSteamDeck) {
@@ -668,22 +668,13 @@ function handleSteamDeckAdvancedOptions(
     ) {
       disableCustomGpuLimit();
     } else {
-      const customGpuLimitEnabled = get(
+      const newMax = get(
         state,
-        `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX_ENABLED}`,
-        false
+        `advanced.${SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX}`,
+        1600
       );
 
-      if (customGpuLimitEnabled) {
-        if (
-          statePath == SteamDeckAdvancedOptions.DECK_CUSTOM_GPU_MAX &&
-          Number(value) >= 1600
-        ) {
-          state.settings.maxGpuFrequency = value;
-        }
-      } else {
-        disableCustomGpuLimit();
-      }
+      set(state, "settings.maxGpuFrequency", newMax || 1600);
     }
   } // end ifSteamDeck
 }

--- a/src/redux-modules/settingsSlice.ts
+++ b/src/redux-modules/settingsSlice.ts
@@ -587,7 +587,7 @@ function handleAdvancedOptionsEdgeCases(
   try {
     handleSteamDeckAdvancedOptions(state, statePath, value);
   } catch (err) {
-    logInfo({ info: JSON.stringify(err, Object.getOwnPropertyNames(err)) });
+    logInfo({ info: err });
   }
   if (statePath === AdvancedOptionsEnum.USE_PLATFORM_PROFILE && value) {
     set(

--- a/src/redux-modules/uiSlice.ts
+++ b/src/redux-modules/uiSlice.ts
@@ -3,7 +3,6 @@ import { createSlice } from "@reduxjs/toolkit";
 import { RootState } from "./store";
 import { fetchPowerControlInfo } from "./thunks";
 import { PowerControlInfo } from "../utils/constants";
-import { Devices } from "../backend/utils";
 
 type UiStateType = {
   powerControlInfo?: PowerControlInfo;
@@ -34,22 +33,6 @@ export const uiSlice = createSlice({
 
 export const selectPowerControlInfo = (state: RootState) => {
   return state.ui.powerControlInfo;
-};
-
-export const selectDeviceName = (state: RootState) => {
-  return state.ui.powerControlInfo?.deviceName || "";
-};
-
-export const selectIsSteamDeck = (state: RootState) => {
-  const deviceName = selectDeviceName(state);
-
-  if (
-    deviceName.includes(Devices.STEAM_DECK_LCD) ||
-    deviceName.includes(Devices.STEAM_DECK_OLED)
-  ) {
-    return true;
-  }
-  return false;
 };
 
 export const selectScalingDriver = (state: RootState) => {

--- a/src/redux-modules/uiSlice.ts
+++ b/src/redux-modules/uiSlice.ts
@@ -3,6 +3,7 @@ import { createSlice } from "@reduxjs/toolkit";
 import { RootState } from "./store";
 import { fetchPowerControlInfo } from "./thunks";
 import { PowerControlInfo } from "../utils/constants";
+import { Devices } from "../backend/utils";
 
 type UiStateType = {
   powerControlInfo?: PowerControlInfo;
@@ -37,6 +38,18 @@ export const selectPowerControlInfo = (state: RootState) => {
 
 export const selectDeviceName = (state: RootState) => {
   return state.ui.powerControlInfo?.deviceName || "";
+};
+
+export const selectIsSteamDeck = (state: RootState) => {
+  const deviceName = selectDeviceName(state);
+
+  if (
+    deviceName.includes(Devices.STEAM_DECK_LCD) ||
+    deviceName.includes(Devices.STEAM_DECK_OLED)
+  ) {
+    return true;
+  }
+  return false;
 };
 
 export const selectScalingDriver = (state: RootState) => {

--- a/src/utils/selectors.tsx
+++ b/src/utils/selectors.tsx
@@ -1,0 +1,18 @@
+import { RootState } from "../redux-modules/store";
+import { Devices } from "../backend/utils";
+
+export const selectDeviceName = (state: RootState) => {
+  return state.ui.powerControlInfo?.deviceName || "";
+};
+
+export const selectIsSteamDeck = (state: RootState) => {
+  const deviceName = selectDeviceName(state);
+
+  if (
+    deviceName.includes(Devices.STEAM_DECK_LCD) ||
+    deviceName.includes(Devices.STEAM_DECK_OLED)
+  ) {
+    return true;
+  }
+  return false;
+};

--- a/src/utils/selectors.tsx
+++ b/src/utils/selectors.tsx
@@ -9,6 +9,10 @@ export const selectDeviceName = (state: RootState) => {
 export const selectIsSteamDeck = (state: RootState) => {
   const deviceName = selectDeviceName(state);
 
+  return isSteamDeck(deviceName);
+};
+
+export function isSteamDeck(deviceName: string) {
   if (
     deviceName.includes(Devices.STEAM_DECK_LCD) ||
     deviceName.includes(Devices.STEAM_DECK_OLED)
@@ -16,4 +20,4 @@ export const selectIsSteamDeck = (state: RootState) => {
     return true;
   }
   return false;
-};
+}

--- a/src/utils/selectors.tsx
+++ b/src/utils/selectors.tsx
@@ -1,8 +1,9 @@
 import { RootState } from "../redux-modules/store";
 import { Devices } from "../backend/utils";
+import { get } from "lodash";
 
 export const selectDeviceName = (state: RootState) => {
-  return state.ui.powerControlInfo?.deviceName || "";
+  return get(state, "ui.powerControlInfo.deviceName", "");
 };
 
 export const selectIsSteamDeck = (state: RootState) => {


### PR DESCRIPTION
Note, you must enable a custom bios on the Deck.

Warning, I currently don't know of any way to automatically verify if a Deck is using a custom bios.