### PR TITLE
Update migrations.py

### DIFF
--- a/py_modules/migrations.py
+++ b/py_modules/migrations.py
@@ -7,10 +7,8 @@ def check_ryzenadj_coall_support():
   if not device_utils.is_intel():
     try:
       settings = get_saved_settings()
-      if settings.get('supportsRyzenadjCoall', None) == None:
-        undervolt_supported = bool(ryzenadj._set_ryzenadj_undervolt(0))
-
-        set_setting('supportsRyzenadjCoall', undervolt_supported)
+      undervolt_supported = bool(ryzenadj._set_ryzenadj_undervolt(0))
+      set_setting('supportsRyzenadjCoall', undervolt_supported)
     except Exception as e:
       decky_plugin.logger.error(f"{__name__} error while checking undervolt support {e}")
 


### PR DESCRIPTION
This change ensures it always checks regardless of the setting in the JSON. This is useful in cases where, for example, I install the plugin and later add the kernel parameter 'amd_pstate=active'; it might happen that undervolting adjustment is supported, but since the check isn't performed (as it's already set in the JSON), it won't appear in the plugin settings.