### PR TITLE
fix: update minimum TDP range from 4 to 3

### DIFF
--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -315,7 +315,7 @@ def get_scaling_driver():
 
 def get_intel_tdp_limits():
   # while there is a max TDP provided by intel, there is no min
-  min_tdp = 4
+  min_tdp = 3
   max_tdp = 15
 
   saved_max_tdp = get_saved_settings().get(INTEL_MAX_TDP_SETTING, None)

--- a/src/utils/constants.tsx
+++ b/src/utils/constants.tsx
@@ -8,7 +8,7 @@ export const CpuVendors = {
   AMD: "AuthenticAMD",
 };
 
-export const MIN_TDP_RANGE = 4;
+export const MIN_TDP_RANGE = 3;
 export const DEFAULT_POLL_RATE = 15000;
 export const DEFAULT_START_TDP = 12;
 


### PR DESCRIPTION
This PR updates the minimum TDP range from 4W to 3W in both the Python and TypeScript configuration files.

The Steam Deck's firmware allows adjusting the TDP down to 3W by the **Quick Access Menu**, which is a supported and stable setting. Previously, this tool limited the minimum to 4W, preventing users from accessing the full low-power potential of the device. This change unlocks finer control for power-efficient usage, especially beneficial for battery life optimization.

I've tested this change on my own Steam Deck, and it works perfectly—allowing smooth operation at 3W without any issues.

This update aligns the tool's limits with the actual hardware capabilities, making it even more versatile for power tuning.

Changes:

- Updated `min_tdp` in `py_modules/cpu_utils.py`
- Updated `MIN_TDP_RANGE` in `src/utils/constants.tsx`
Tested and confirmed working.