### PR TITLE
Feature/legion go s z1 extreme support

### DIFF
--- a/main.py
+++ b/main.py
@@ -13,6 +13,7 @@ import plugin_utils
 import migrations
 import steam_info
 import device_utils
+from devices import lenovo
 import charge_limit
 
 class Plugin:
@@ -156,6 +157,13 @@ class Plugin:
     decky_plugin.logger.info(f'main#on_suspend started')
     cpu_utils.set_smt(True)
     decky_plugin.logger.info(f'main#on_suspend complete')
+
+  async def on_resume(self):
+    decky_plugin.logger.info(f'main#on_resume started')
+    if device_utils.is_legion_go():
+      lenovo.invalidate_platform_profile_cache()
+      lenovo.wait_for_wmi_ready(timeout_seconds=10)
+    decky_plugin.logger.info(f'main#on_resume complete')
 
   async def persist_cpu_boost(self, cpuBoost, gameId):
     tdp_profiles = {

--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
   },
   "dependencies": {
     "@decky/api": "^1.0.6",
-    "@decky/ui": "^4.4.0",
+    "@decky/ui": "^4.11.1",
     "@reduxjs/toolkit": "^1.9.7",
     "lodash": "^4.17.21",
     "mobx": "^6.13.7",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -12,8 +12,8 @@ importers:
         specifier: ^1.0.6
         version: 1.1.2
       '@decky/ui':
-        specifier: ^4.4.0
-        version: 4.10.0
+        specifier: ^4.11.1
+        version: 4.11.1
       '@reduxjs/toolkit':
         specifier: ^1.9.7
         version: 1.9.7(react-redux@8.1.3(@types/react-dom@18.3.0)(@types/react@18.3.3)(react@18.3.1)(redux@4.2.1))(react@18.3.1)
@@ -94,8 +94,8 @@ packages:
   '@decky/rollup@1.0.1':
     resolution: {integrity: sha512-dx1VJwD7ul14PA/aZvOwAfY/GujHzqZJ+MFb4OIUVi63/z4KWMSuZrK6QWo0S4LrNW3RzB3ua6LT0WcJaNY9gw==}
 
-  '@decky/ui@4.10.0':
-    resolution: {integrity: sha512-uE5DTDnnwlsNI5hVl/nQ+5lwe/etszXSKWEbu9DMYpsV9uK54Jpg9F5IA4lMXQ8UL3mQL6jb8j6fXLfkI1HIrQ==}
+  '@decky/ui@4.11.1':
+    resolution: {integrity: sha512-+x+rJB0MBQSQGp0UpsRJ4BOv7zlHzcBPT76enopjGf56H41beR8VZua9F4upLtDgPku4Zh8z3uB53nFlvTilXQ==}
 
   '@isaacs/cliui@8.0.2':
     resolution: {integrity: sha512-O8jcjabXaleOG9DQ0+ARXWZBTfnP4WNAqzuiJK7ll44AmxGKv/J2M4TPjxjY3znBCfvBXFzucm1twdyFybFqEA==}
@@ -241,56 +241,67 @@ packages:
     resolution: {integrity: sha512-46OzWeqEVQyX3N2/QdiU/CMXYDH/lSHpgfBkuhl3igpZiaB3ZIfSjKuOnybFVBQzjsLwkus2mjaESy8H41SzvA==}
     cpu: [arm]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm-musleabihf@4.41.0':
     resolution: {integrity: sha512-lfgW3KtQP4YauqdPpcUZHPcqQXmTmH4nYU0cplNeW583CMkAGjtImw4PKli09NFi2iQgChk4e9erkwlfYem6Lg==}
     cpu: [arm]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-arm64-gnu@4.41.0':
     resolution: {integrity: sha512-nn8mEyzMbdEJzT7cwxgObuwviMx6kPRxzYiOl6o/o+ChQq23gfdlZcUNnt89lPhhz3BYsZ72rp0rxNqBSfqlqw==}
     cpu: [arm64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-arm64-musl@4.41.0':
     resolution: {integrity: sha512-l+QK99je2zUKGd31Gh+45c4pGDAqZSuWQiuRFCdHYC2CSiO47qUWsCcenrI6p22hvHZrDje9QjwSMAFL3iwXwQ==}
     cpu: [arm64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-loongarch64-gnu@4.41.0':
     resolution: {integrity: sha512-WbnJaxPv1gPIm6S8O/Wg+wfE/OzGSXlBMbOe4ie+zMyykMOeqmgD1BhPxZQuDqwUN+0T/xOFtL2RUWBspnZj3w==}
     cpu: [loong64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-powerpc64le-gnu@4.41.0':
     resolution: {integrity: sha512-eRDWR5t67/b2g8Q/S8XPi0YdbKcCs4WQ8vklNnUYLaSWF+Cbv2axZsp4jni6/j7eKvMLYCYdcsv8dcU+a6QNFg==}
     cpu: [ppc64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-gnu@4.41.0':
     resolution: {integrity: sha512-TWrZb6GF5jsEKG7T1IHwlLMDRy2f3DPqYldmIhnA2DVqvvhY2Ai184vZGgahRrg8k9UBWoSlHv+suRfTN7Ua4A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-riscv64-musl@4.41.0':
     resolution: {integrity: sha512-ieQljaZKuJpmWvd8gW87ZmSFwid6AxMDk5bhONJ57U8zT77zpZ/TPKkU9HpnnFrM4zsgr4kiGuzbIbZTGi7u9A==}
     cpu: [riscv64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-linux-s390x-gnu@4.41.0':
     resolution: {integrity: sha512-/L3pW48SxrWAlVsKCN0dGLB2bi8Nv8pr5S5ocSM+S0XCn5RCVCXqi8GVtHFsOBBCSeR+u9brV2zno5+mg3S4Aw==}
     cpu: [s390x]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-gnu@4.41.0':
     resolution: {integrity: sha512-XMLeKjyH8NsEDCRptf6LO8lJk23o9wvB+dJwcXMaH6ZQbbkHu2dbGIUindbMtRN6ux1xKi16iXWu6q9mu7gDhQ==}
     cpu: [x64]
     os: [linux]
+    libc: [glibc]
 
   '@rollup/rollup-linux-x64-musl@4.41.0':
     resolution: {integrity: sha512-m/P7LycHZTvSQeXhFmgmdqEiTqSV80zn6xHaQ1JSqwCtD1YGtwEK515Qmy9DcB2HK4dOUVypQxvhVSy06cJPEg==}
     cpu: [x64]
     os: [linux]
+    libc: [musl]
 
   '@rollup/rollup-win32-arm64-msvc@4.41.0':
     resolution: {integrity: sha512-4yodtcOrFHpbomJGVEqZ8fzD4kfBeCbpsUy5Pqk4RluXOdsWdjLnjhiKy2w3qzcASWd04fp52Xz7JKarVJ5BTg==}
@@ -1073,7 +1084,7 @@ snapshots:
       tslib: 2.8.1
       typescript: 5.8.3
 
-  '@decky/ui@4.10.0': {}
+  '@decky/ui@4.11.1': {}
 
   '@isaacs/cliui@8.0.2':
     dependencies:

--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -88,14 +88,17 @@ def set_amd_tdp(tdp: int):
         )
         and lenovo.supports_wmi_tdp()
       ):
-        return lenovo.set_tdp(tdp)
+        result = lenovo.set_tdp(tdp)
+        if not result:
+          decky_plugin.logger.error(f"{__name__} Lenovo WMI TDP failed, not falling back to ryzenadj")
+        return result
       elif device_utils.is_rog_ally() or device_utils.is_rog_ally_x():
         if advanced_options.get_setting(RogAllySettings.USE_PLATFORM_PROFILE.value):
           rog_ally.set_platform_profile(tdp)
         if advanced_options.get_setting(RogAllySettings.USE_WMI.value) and rog_ally.supports_wmi_tdp():
           return rog_ally.set_tdp(tdp)
 
-    # use ryzenadj by default
+    # use ryzenadj by default (only for non-WMI devices)
     return ryzenadj.set_tdp(tdp)
   except Exception as e:
     decky_plugin.logger.error(e)

--- a/py_modules/device_utils.py
+++ b/py_modules/device_utils.py
@@ -5,7 +5,8 @@ import re
 
 class Devices(Enum):
   LEGION_GO = "83E1"
-  LEGION_GO_S = "83L3"
+  LEGION_GO_S_Z2_GO = "83L3"
+  LEGION_GO_S_Z1_EXTREME = "83N6"
   ROG_ALLY = "ROG Ally RC71"
   ROG_ALLY_X = "ROG Ally X RC72"
   MINISFORUM_V3 = "V3"
@@ -121,7 +122,9 @@ def is_legion_go():
 
   if device_name == Devices.LEGION_GO.value:
     return True
-  if device_name == Devices.LEGION_GO_S.value:
+  if device_name == Devices.LEGION_GO_S_Z2_GO.value:
+    return True
+  if device_name == Devices.LEGION_GO_S_Z1_EXTREME.value:
     return True
   return False
 

--- a/py_modules/devices/lenovo.py
+++ b/py_modules/devices/lenovo.py
@@ -35,21 +35,45 @@ def get_platform_profile_path():
 
   return PLATFORM_PROFILE_PATH
 
-def set_tdp(tdp):
-  set_platform_profile("custom")
-  if (
-    os.path.exists(LENOVO_WMI_FAST_PATH)
-    and os.path.exists(LENOVO_WMI_SLOW_PATH)
-    and os.path.exists(LENOVO_WMI_STAPM_PATH)
-  ):
-    decky_plugin.logger.info(f"{__name__} Setting Lenovo WMI TDP {tdp}")
+def set_tdp(tdp, max_retries=3):
+  for attempt in range(max_retries):
+    profile_ok = set_platform_profile("custom")
+    if not profile_ok and attempt < max_retries - 1:
+      delay = 0.3 * (attempt + 1)
+      decky_plugin.logger.warning(f"{__name__} platform profile failed, retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+      sleep(delay)
+      continue
 
-    sleep(0.1)
-    set_suffix_tdp(tdp, FAST_SUFFIX)
-    sleep(0.1)
-    set_suffix_tdp(tdp, SLOW_SUFFIX)
-    sleep(0.1)
-    set_suffix_tdp(tdp, STAPM_SUFFIX)
+    if (
+      os.path.exists(LENOVO_WMI_FAST_PATH)
+      and os.path.exists(LENOVO_WMI_SLOW_PATH)
+      and os.path.exists(LENOVO_WMI_STAPM_PATH)
+    ):
+      decky_plugin.logger.info(f"{__name__} Setting Lenovo WMI TDP {tdp}")
+
+      sleep(0.3)
+      ok_fast = set_suffix_tdp(tdp, FAST_SUFFIX)
+      sleep(0.3)
+      ok_slow = set_suffix_tdp(tdp, SLOW_SUFFIX)
+      sleep(0.3)
+      ok_stapm = set_suffix_tdp(tdp, STAPM_SUFFIX)
+
+      if ok_fast and ok_slow and ok_stapm:
+        return True
+
+      if attempt < max_retries - 1:
+        delay = 0.3 * (attempt + 1)
+        decky_plugin.logger.warning(f"{__name__} TDP write incomplete, retrying in {delay}s (attempt {attempt + 1}/{max_retries})")
+        sleep(delay)
+        continue
+
+    decky_plugin.logger.error(f"{__name__} WMI TDP paths not found (attempt {attempt + 1}/{max_retries})")
+    if attempt < max_retries - 1:
+      delay = 0.3 * (attempt + 1)
+      sleep(delay)
+
+  decky_plugin.logger.error(f"{__name__} Failed to set TDP {tdp} after {max_retries} attempts")
+  return False
 
 def supports_wmi_tdp():
   if (
@@ -62,31 +86,45 @@ def supports_wmi_tdp():
     return True
   return False
 
-def set_platform_profile(profile: str) -> None:
-  set_profile_path = os.path.join(get_platform_profile_path(), "profile")
-  if os.path.exists(set_profile_path):
-    decky_plugin.logger.info(f'setting profile {profile} to path {set_profile_path}')
-    try:
+def set_platform_profile(profile: str) -> bool:
+  try:
+    profile_base = get_platform_profile_path()
+    if not profile_base:
+      decky_plugin.logger.error(f"{__name__} Platform profile path not found")
+      return False
+    set_profile_path = os.path.join(profile_base, "profile")
+    if os.path.exists(set_profile_path):
+      decky_plugin.logger.info(f'setting profile {profile} to path {set_profile_path}')
       with open(set_profile_path, "w") as f:
         f.write(profile)
-    except Exception as e:
-      decky_plugin.logger.error(f"{__name__} Failed to set platform profile {profile}: {e}")
+      return True
+    else:
+      decky_plugin.logger.error(f"{__name__} Profile path does not exist: {set_profile_path}")
+      return False
+  except Exception as e:
+    decky_plugin.logger.error(f"{__name__} Failed to set platform profile {profile}: {e}")
+    return False
 
-def set_suffix_tdp(tdp: int, suffix: str):
+def set_suffix_tdp(tdp: int, suffix: str) -> bool:
   suffix_path = f'{LENOVO_WMI_PATH}/{suffix}/current_value'
 
-  with open(suffix_path, "w") as f:
-    min, max = get_tdp_limit(suffix)
+  try:
+    with open(suffix_path, "w") as f:
+      min, max = get_tdp_limit(suffix)
 
-    tdp_value = tdp
+      tdp_value = tdp
 
-    if min and tdp_value < min:
-      tdp_value = min
-    if max and tdp_value > max:
-      tdp_value = max
+      if min and tdp_value < min:
+        tdp_value = min
+      if max and tdp_value > max:
+        tdp_value = max
 
-    f.write(str(tdp_value))
-    decky_plugin.logger.info(f'set {suffix} WMI TDP {tdp_value}')
+      f.write(str(tdp_value))
+      decky_plugin.logger.info(f'set {suffix} WMI TDP {tdp_value}')
+    return True
+  except Exception as e:
+    decky_plugin.logger.error(f"{__name__} Failed to write {suffix} TDP: {e}")
+    return False
 
 def get_tdp_limit(suffix: str):
   min = get_min_tdp(suffix)
@@ -107,3 +145,20 @@ def get_max_tdp(suffix: str):
     with open(f"{LENOVO_WMI_PATH}/{suffix}/max_value", "r") as f:
       max_tdp = int(f.read())
   return max_tdp
+
+def invalidate_platform_profile_cache():
+  global PLATFORM_PROFILE_PATH
+  PLATFORM_PROFILE_PATH = None
+  decky_plugin.logger.info(f"{__name__} Invalidated platform profile cache")
+
+def wait_for_wmi_ready(timeout_seconds=10):
+  elapsed = 0
+  interval = 0.5
+  while elapsed < timeout_seconds:
+    if supports_wmi_tdp():
+      decky_plugin.logger.info(f"{__name__} WMI ready after {elapsed}s")
+      return True
+    sleep(interval)
+    elapsed += interval
+  decky_plugin.logger.warning(f"{__name__} WMI not ready after {timeout_seconds}s timeout")
+  return False

--- a/py_modules/plugin_timeout.py
+++ b/py_modules/plugin_timeout.py
@@ -1,10 +1,17 @@
 import signal
+import threading
 from contextlib import contextmanager
 
 class TimeoutException(Exception): pass
 
 @contextmanager
 def time_limit(seconds):
+  if threading.current_thread() is not threading.main_thread():
+    # SIGALRM only works on the main thread; skip timeout
+    yield
+    return
+
+  prev_handler = signal.getsignal(signal.SIGALRM)
   def signal_handler(signum, frame):
     raise TimeoutException("Timed out!")
   signal.signal(signal.SIGALRM, signal_handler)
@@ -13,3 +20,4 @@ def time_limit(seconds):
     yield
   finally:
     signal.alarm(0)
+    signal.signal(signal.SIGALRM, prev_handler)

--- a/src/backend/utils.tsx
+++ b/src/backend/utils.tsx
@@ -3,7 +3,8 @@ import { IS_DESKTOP } from "../components/atoms/DeckyFrontendLib";
 
 export enum Devices {
   LEGION_GO = "83E1",
-  LEGION_GO_S = "83L3",
+  LEGION_GO_S_Z2_GO = "83L3",
+  LEGION_GO_S_Z1_EXTREME = "83N6",
   ROG_ALLY = "ROG Ally RC71",
   ROG_ALLY_X = "ROG Ally X RC72",
   MINISFORUM_V3 = "V3",
@@ -98,6 +99,7 @@ export enum ServerAPIMethods {
   PERSIST_GPU = "persist_gpu",
   PERSIST_SMT = "persist_smt",
   ON_SUSPEND = "on_suspend",
+  ON_RESUME = "on_resume",
   OTA_UPDATE = "ota_update",
   PERSIST_CPU_BOOST = "persist_cpu_boost",
   SET_VALUES_FOR_GAME_ID = "set_values_for_game_id",
@@ -122,6 +124,7 @@ export const setSetting = ({ name, value }: { name: string; value: any }) => {
   return call(ServerAPIMethods.SET_SETTING, name, value);
 };
 export const onSuspend = callable(ServerAPIMethods.ON_SUSPEND);
+export const onResume = callable(ServerAPIMethods.ON_RESUME);
 
 export const setPollTdp = ({ currentGameId }: { currentGameId: string }) => {
   if (IS_DESKTOP) {

--- a/src/steamListeners.tsx
+++ b/src/steamListeners.tsx
@@ -14,6 +14,7 @@ import {
   getCurrentAcPowerStatus,
   getSupportsCustomAcPower,
   logInfo,
+  onResume as backendOnResume,
   setMaxTdp,
   setPollTdp,
 } from "./backend/utils";
@@ -140,6 +141,12 @@ export const suspendEventListener = () => {
 };
 
 const onResume = async () => {
+  try {
+    await backendOnResume();
+  } catch (e) {
+    logInfo({ info: `backend onResume error: ${e}` });
+  }
+
   setTimeout(() => {
     const state = store.getState();
 


### PR DESCRIPTION
**Summary**

I noticed that SimpleDeckyTDP often crashed on the Legion Go S Z1 Extreme Device. The main issue was that it was not properly detected, since its device name differs from the Z2 Go variant.

Changes in this Pull Request:
  
- Add device detection for the Legion Go S Z1 Extreme (product ID 83N6) alongside the existing Z2 Go variant (83L3)                                                                                                                                                                                                       
- Implement suspend/resume lifecycle handling for Legion Go devices — invalidate WMI cache on resume, wait for WMI readiness before restoring TDP
- Improve Lenovo WMI TDP reliability with retry logic (up to 3 attempts with progressive backoff), proper error propagation via boolean return values, and no silent fallback to ryzenadj on failure - Fix plugin_timeout thread safety — SIGALRM only works on the main thread, so the timeout is now skipped on worker threads, and the previous signal handler is correctly restored
- Bump @decky/ui from 4.4.0 to 4.11.1

**Details**

Legion Go S Z1 Extreme support

The Legion Go S ships with two processor variants. The Z2 Go model (83L3) was already supported. This PR adds detection for the Z1 Extreme model (83N6). The LEGION_GO_S enum has been renamed to LEGION_GO_S_Z2_GO to distinguish the two variants. Both Python and TypeScript device enums are kept in sync.

**Suspend/resume lifecycle**

On Legion Go devices, the WMI interface can become temporarily unavailable after resuming from suspend. Previously this caused silent TDP write failures. The new on_resume handler:
1. Invalidates the cached platform profile path (which may have changed or become stale)
2. Polls for WMI readiness with a configurable timeout (default 10s)
3. Only then allows TDP to be reapplied by the frontend

**WMI TDP reliability**

set_tdp() now retries up to 3 times with progressive backoff (0.3s, 0.6s, 0.9s) if either the platform profile write or TDP value writes fail. Both set_platform_profile() and set_suffix_tdp() now return bool to indicate success/failure, and set_suffix_tdp() is wrapped in a try/except to handle I/O errors gracefully. On the caller side (cpu_utils.py), a failed WMI TDP write is logged as an error and no longer silently falls through to ryzenadj.

**Thread-safe timeout**

plugin_timeout.time_limit() uses SIGALRM, which raises an exception on non-main threads. The context manager now detects this case and yields without setting an alarm. The previous signal handler is also restored in the finally block to avoid leaking state.
