### PR TITLE
Fix Intel handheld errors: xe-driver GPU clocks + skip SMT toggle when unsupported

### DIFF
--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -177,8 +177,14 @@ def set_cpu_boost(enabled = True):
     return False
 
 def supports_smt():
-  if os.path.exists(SMT_PATH):
-    return True
+  try:
+    if os.path.exists(SMT_PATH):
+      with open(SMT_PATH, 'r') as file:
+        state = file.read().strip()
+      # 'notsupported' / 'notimplemented' / 'forceoff' cannot be toggled
+      return state in ('on', 'off')
+  except Exception as e:
+    decky_plugin.logger.error(e)
 
   return False
 
@@ -186,6 +192,13 @@ def set_smt(enabled = True):
   try:
     # SMT_PATH is identical for both AMD and Intel
     if os.path.exists(SMT_PATH):
+      with open(SMT_PATH, 'r') as file:
+        state = file.read().strip()
+      # skip when SMT can't be toggled (CPUs without HyperThreading report
+      # 'notsupported'/'notimplemented'/'forceoff' and the kernel returns
+      # -ENODEV/-EPERM on write)
+      if state not in ('on', 'off'):
+        return True
       with open(SMT_PATH, 'w') as file:
         if enabled:
           file.write('on')

--- a/py_modules/gpu_utils.py
+++ b/py_modules/gpu_utils.py
@@ -185,20 +185,27 @@ def set_amd_gpu_frequency_range(new_min, new_max):
 
 def get_intel_gpu_clocks():
   try:
-    env = os.environ.copy()
-    env["LD_LIBRARY_PATH"] = ""
+    # legacy i915 layout
+    max_files = glob.glob("/sys/class/drm/card?/gt_max_freq_mhz")
+    min_files = glob.glob("/sys/class/drm/card?/gt_min_freq_mhz")
 
-    max_cmd = 'cat /sys/class/drm/card?/gt_max_freq_mhz'
-    max_result = subprocess.run(max_cmd, shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
-    max_gpu_clock = int(max_result.stdout.strip())
+    # xe driver layout (Arc / Core Ultra iGPUs): no gt_*_freq_mhz at card root,
+    # frequencies live under device/tile*/gt*/freq*/{min,max}_freq
+    if not (max_files and min_files):
+      max_files = glob.glob("/sys/class/drm/card?/device/tile*/gt*/freq*/max_freq")
+      min_files = glob.glob("/sys/class/drm/card?/device/tile*/gt*/freq*/min_freq")
 
-    min_cmd = 'cat /sys/class/drm/card?/gt_min_freq_mhz'
-    min_result = subprocess.run(min_cmd, shell=True, check=True, text=True, stdout=subprocess.PIPE, stderr=subprocess.PIPE, env=env)
-    min_gpu_clock = int(min_result.stdout.strip())
+    if not (max_files and min_files):
+      raise FileNotFoundError("no intel gpu frequency sysfs path found")
+
+    with open(sorted(max_files)[0], 'r') as f:
+      max_gpu_clock = int(f.read().strip())
+    with open(sorted(min_files)[0], 'r') as f:
+      min_gpu_clock = int(f.read().strip())
 
     return [min_gpu_clock, max_gpu_clock]
   except Exception as e:
-    decky_plugin.logger.error('error while getting intel gpu clocks')
+    decky_plugin.logger.error(f'error while getting intel gpu clocks {e}')
     return [None, None]
   
 def get_env():


### PR DESCRIPTION
Two small, independent fixes for Intel handhelds, tested on an MSI Claw (Panther Lake, `xe` driver, CPU reports SMT `notsupported`). Each is its own commit so they can be taken separately. Both are backward-compatible.

### 1. Skip SMT toggle when `notsupported`
`set_smt()` wrote `on`/`off` to `/sys/devices/system/cpu/smt/control` whenever the path existed. On CPUs without Hyper-Threading the file reads `notsupported`, so the kernel rejects the write with `-ENODEV` — logging `[Errno 19] No such device` on every TDP poll (~every 15s):

```
[INFO]: gpu controls disabled, exiting set_gpu_frequency_range
[ERROR]: [Errno 19] No such device
```

Now `set_smt()` reads the control file first and only writes when the value is actually `on`/`off`. `supports_smt()` likewise returns `False` for `notsupported`/`notimplemented`/`forceoff`, so the frontend hides the SMT toggle instead of offering a control that can't work.

### 2. Read Intel GPU clocks from the `xe` driver layout
`get_intel_gpu_clocks()` only read the i915 layout (`/sys/class/drm/card?/gt_{max,min}_freq_mhz`). Recent Intel iGPUs (Arc / Core Ultra / Lunar Lake / Panther Lake) use the **`xe`** driver, where those files don't exist and the clocks live under `device/tile*/gt*/freq*/{min,max}_freq`. The old code logged `error while getting intel gpu clocks` on load and left the GPU frequency range unset.

It now globs the i915 path first and falls back to the `xe` path, reading the sysfs files directly instead of shelling out to `cat`. (Setting Intel GPU clocks remains disabled as before — this only restores the read-only range readout.)

### Testing
On an MSI Claw (`xe` driver, `smt/control` = `notsupported`): both error lines are gone from the plugin log after the change, and `get_intel_gpu_clocks()` returns the correct range (550–2300 MHz) via the `xe` paths.
