### PR TITLE
Replace magic number 1000000 with MICROWATTS_PER_WATT constant

### DIFF
--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -29,6 +29,9 @@ INTEL_MAX_TDP_SETTING = 'INTEL_MAX_TDP_SETTING'
 # as a safety mitigation, 40W to be used as as a ceiling for PC handheld devices
 INTEL_MAX_TDP = 40
 
+# sysfs intel-rapl power limits are in microwatts (path suffix `_uw`)
+MICROWATTS_PER_WATT = 1_000_000
+
 class ScalingDrivers(Enum):
   INTEL_CPUFREQ = "intel_cpufreq"
   INTEL_PSTATE = "intel_pstate"
@@ -357,11 +360,11 @@ def get_intel_max_tdp():
 
       if os.path.exists(MAX_TDP_PATH):
         with open(MAX_TDP_PATH, 'r') as file:
-          max_tdp = int(file.read().strip()) / 1000000
+          max_tdp = int(file.read().strip()) / MICROWATTS_PER_WATT
           file.close()
       if os.path.exists(ALTERNATIVE_MAX_TDP_PATH):
         with open(ALTERNATIVE_MAX_TDP_PATH, 'r') as file:
-          alt_max_tdp = int(file.read().strip()) / 1000000
+          alt_max_tdp = int(file.read().strip()) / MICROWATTS_PER_WATT
           file.close()
 
       if alt_max_tdp >= max_tdp:
@@ -379,7 +382,7 @@ def get_intel_max_tdp():
   return maximum_tdp
 
 def execute_tdp_command(tdp, tdp_path):
-  tdp_microwatts = tdp * 1000000
+  tdp_microwatts = tdp * MICROWATTS_PER_WATT
   try:
     if os.path.exists(tdp_path):
       with open(tdp_path, 'w') as file:


### PR DESCRIPTION
## Summary

Replaces the repeated `1000000` literal in `cpu_utils.py` with a named `MICROWATTS_PER_WATT` constant.

The intel-rapl sysfs power limits are expressed in microwatts (the `_uw` path suffix). Extracting the watts↔microwatts conversion factor into a named constant makes the TDP read/write call sites self-documenting.

## Changes

- Added `MICROWATTS_PER_WATT = 1_000_000` near the other module constants
- Used it in the 3 conversion sites (2 reads in `get_intel_max_tdp`, 1 write in `execute_tdp_command`)

No behavior change — pure readability refactor.