### PR TITLE
feat(legion-go): battery charge limit for Legion Go & Legion Go 2

### DIFF
--- a/defaults/i18n/en.json
+++ b/defaults/i18n/en.json
@@ -55,6 +55,8 @@
   "MAX_TDP_ON_AC_POWER": "Always use Max TDP on AC power",
   "MAX_TDP_ON_AC_POWER_DESC": "When plugged into AC power, always use max TDP. Per-game profiles must be enabled",
   "ADVANCED_ENABLE_CHARGE_LIMIT": "Enable Battery Charge Limit",
+  "ADVANCED_ENABLE_CHARGE_LIMIT_DESC": "Limit battery charging to help preserve long-term battery health",
+  "ADVANCED_ENABLE_CHARGE_LIMIT_CONSERVATION_DESC": "Caps battery charge at ~80%",
   "ADVANCED_SET_CHARGE_LIMIT": "Set Battery Charge Limit",
   "ADVANCED_SET_CHARGE_LIMIT_DESC": "Set maximum battery limit",
   "ADVANCED_ENABLE_BACKGROUND_POLLING": "Enable Background Polling",

--- a/defaults/i18n/template.json
+++ b/defaults/i18n/template.json
@@ -55,6 +55,8 @@
   "MAX_TDP_ON_AC_POWER": "Always use Max TDP on AC power",
   "MAX_TDP_ON_AC_POWER_DESC": "When plugged into AC power, always use max TDP. Per-game profiles must be enabled",
   "ADVANCED_ENABLE_CHARGE_LIMIT": "Enable Battery Charge Limit",
+  "ADVANCED_ENABLE_CHARGE_LIMIT_DESC": "Limit battery charging to help preserve long-term battery health",
+  "ADVANCED_ENABLE_CHARGE_LIMIT_CONSERVATION_DESC": "Caps battery charge at ~80%",
   "ADVANCED_SET_CHARGE_LIMIT": "Set Battery Charge Limit",
   "ADVANCED_SET_CHARGE_LIMIT_DESC": "Set maximum battery limit",
   "ADVANCED_ENABLE_BACKGROUND_POLLING": "Enable Background Polling",

--- a/py_modules/advanced_options.py
+++ b/py_modules/advanced_options.py
@@ -167,34 +167,43 @@ def get_default_options():
 
   options.append(max_tdp_on_ac_power)
 
-  # if charge_limit.supports_charge_limit():
-  #   range, default_value, step = charge_limit.get_range_info()
+  if charge_limit.supports_charge_limit():
+    if charge_limit.uses_conservation_mode():
+      # Lenovo Legion: fixed ~80% firmware cap (Conservation Mode), not a settable %
+      charge_limit_desc = t('ADVANCED_ENABLE_CHARGE_LIMIT_CONSERVATION_DESC', 'Caps battery charge at ~80%')
+    else:
+      charge_limit_desc = t('ADVANCED_ENABLE_CHARGE_LIMIT_DESC', 'Limit battery charging to help preserve long-term battery health')
 
-  #   options.append({
-  #     'name': t('ADVANCED_ENABLE_CHARGE_LIMIT', 'Enable Battery Charge Limit'),
-  #     'type': AdvancedOptionsType.BOOLEAN.value,
-  #     'defaultValue': False,
-  #     'currentValue': get_value(DefaultSettings.ENABLE_CHARGE_LIMIT, False),
-  #     'statePath': DefaultSettings.ENABLE_CHARGE_LIMIT.value
-  #   })
+    options.append({
+      'name': t('ADVANCED_ENABLE_CHARGE_LIMIT', 'Enable Battery Charge Limit'),
+      'type': AdvancedOptionsType.BOOLEAN.value,
+      'defaultValue': False,
+      'description': charge_limit_desc,
+      'currentValue': get_value(DefaultSettings.ENABLE_CHARGE_LIMIT, False),
+      'statePath': DefaultSettings.ENABLE_CHARGE_LIMIT.value
+    })
 
-  #   set_charge_limit_option = {
-  #     'name': t('ADVANCED_SET_CHARGE_LIMIT', 'Set Battery Charge Limit'),
-  #     'type': AdvancedOptionsType.NUMBER_RANGE.value,
-  #     'range': range,
-  #     'defaultValue': default_value,
-  #     'step': step,
-  #     'valueSuffix': '%',
-  #     'description': t('ADVANCED_SET_CHARGE_LIMIT_DESC', 'Sets max battery limit'),
-  #     'currentValue': get_number_value(DefaultSettings.CHARGE_LIMIT, default_value),
-  #     'statePath': DefaultSettings.CHARGE_LIMIT.value,
-  #     'disabled': {
-  #       'ifFalsy': [DefaultSettings.ENABLE_CHARGE_LIMIT.value],
-  #       'hideIfDisabled': True
-  #     }
-  #   }
+    # devices with a percentage range (e.g. ROG Ally) also get a limit slider;
+    # boolean conservation-mode devices (e.g. Legion Go) get only the toggle
+    charge_range_info = charge_limit.get_range_info()
+    if charge_range_info:
+      charge_range, charge_default, charge_step = charge_range_info
 
-  #   options.append(set_charge_limit_option)
+      options.append({
+        'name': t('ADVANCED_SET_CHARGE_LIMIT', 'Set Battery Charge Limit'),
+        'type': AdvancedOptionsType.NUMBER_RANGE.value,
+        'range': charge_range,
+        'defaultValue': charge_default,
+        'step': charge_step,
+        'valueSuffix': '%',
+        'description': t('ADVANCED_SET_CHARGE_LIMIT_DESC', 'Sets max battery limit'),
+        'currentValue': get_number_value(DefaultSettings.CHARGE_LIMIT, charge_default),
+        'statePath': DefaultSettings.CHARGE_LIMIT.value,
+        'disabled': {
+          'ifFalsy': [DefaultSettings.ENABLE_CHARGE_LIMIT.value],
+          'hideIfDisabled': True
+        }
+      })
 
   enable_background_polling = {
     'name': t('ADVANCED_ENABLE_BACKGROUND_POLLING', 'Enable Background Polling'),
@@ -462,7 +471,15 @@ def handle_advanced_option_change(new_values):
 
       if isinstance(powersave_enabled, bool):
         rog_ally.set_mcu_powersave(powersave_enabled)
-    if charge_limit.supports_charge_limit():
+
+  # charge limit applies to any supported device (hoisted out of the ROG Ally branch)
+  if charge_limit.supports_charge_limit():
+    if charge_limit.uses_conservation_mode():
+      # Lenovo Legion: boolean conservation toggle driven by enableChargeLimit
+      enable_charge_limit = new_values.get(DefaultSettings.ENABLE_CHARGE_LIMIT.value, None)
+      if isinstance(enable_charge_limit, bool):
+        charge_limit.set_conservation(enable_charge_limit)
+    else:
       new_charge_limit = new_values.get(DefaultSettings.CHARGE_LIMIT.value, None)
       if (isinstance(new_charge_limit, int)
         and new_charge_limit >= charge_limit.charge_limit_min()

--- a/py_modules/advanced_options.py
+++ b/py_modules/advanced_options.py
@@ -168,7 +168,7 @@ def get_default_options():
   options.append(max_tdp_on_ac_power)
 
   if charge_limit.supports_charge_limit():
-    if charge_limit.uses_conservation_mode():
+    if charge_limit.uses_boolean_charge_limit():
       # Lenovo Legion: fixed ~80% firmware cap (Conservation Mode), not a settable %
       charge_limit_desc = t('ADVANCED_ENABLE_CHARGE_LIMIT_CONSERVATION_DESC', 'Caps battery charge at ~80%')
     else:
@@ -184,7 +184,7 @@ def get_default_options():
     })
 
     # devices with a percentage range (e.g. ROG Ally) also get a limit slider;
-    # boolean conservation-mode devices (e.g. Legion Go) get only the toggle
+    # boolean charge-limit devices (e.g. Legion Go) get only the toggle
     charge_range_info = charge_limit.get_range_info()
     if charge_range_info:
       charge_range, charge_default, charge_step = charge_range_info
@@ -474,11 +474,11 @@ def handle_advanced_option_change(new_values):
 
   # charge limit applies to any supported device (hoisted out of the ROG Ally branch)
   if charge_limit.supports_charge_limit():
-    if charge_limit.uses_conservation_mode():
-      # Lenovo Legion: boolean conservation toggle driven by enableChargeLimit
+    if charge_limit.uses_boolean_charge_limit():
+      # Lenovo Legion: boolean charge-limit toggle driven by enableChargeLimit
       enable_charge_limit = new_values.get(DefaultSettings.ENABLE_CHARGE_LIMIT.value, None)
       if isinstance(enable_charge_limit, bool):
-        charge_limit.set_conservation(enable_charge_limit)
+        charge_limit.set_boolean_charge_limit(enable_charge_limit)
     else:
       new_charge_limit = new_values.get(DefaultSettings.CHARGE_LIMIT.value, None)
       if (isinstance(new_charge_limit, int)

--- a/py_modules/charge_limit.py
+++ b/py_modules/charge_limit.py
@@ -7,7 +7,15 @@ def uses_boolean_charge_limit():
   # Lenovo Legion exposes a fixed firmware ~80% cap (ideapad conservation_mode or
   # power_supply charge_types) - a boolean toggle, not a percentage slider. Gate
   # on capability (node exists) rather than product id.
-  return (not device_utils.is_rog_ally_series()) and lenovo.supports_charge_limit()
+  # Defer to the native charge-limit interface (charge_control_end_threshold, used
+  # by Steam and the ROG Ally path) when it exists - only fall back to the boolean
+  # toggle when there's no standard threshold node, so we don't overlap if Steam
+  # adds native Legion Go charge-limit support.
+  return (
+    not device_utils.is_rog_ally_series()
+    and not rog_ally.supports_charge_limit()
+    and lenovo.supports_charge_limit()
+  )
 
 def get_range_info():
   if device_utils.is_rog_ally_series():

--- a/py_modules/charge_limit.py
+++ b/py_modules/charge_limit.py
@@ -1,13 +1,19 @@
-from devices import rog_ally
+from devices import rog_ally, lenovo
 from plugin_settings import get_nested_setting
 import device_utils
 from time import sleep
+
+def uses_conservation_mode():
+  # Lenovo Legion (ideapad conservation_mode) is a boolean ~80% cap, not a
+  # percentage slider. Gate on capability (node exists) rather than product id.
+  return (not device_utils.is_rog_ally_series()) and lenovo.supports_charge_limit()
 
 def get_range_info():
   if device_utils.is_rog_ally_series():
     default = 100
     step = 5
     return [[charge_limit_min(), 100], default, step]
+  # conservation-mode devices are boolean-only, no percentage range
   return None
 
 def charge_limit_min():
@@ -19,10 +25,14 @@ def charge_limit_min():
 def get_current_charge_limit():
   if device_utils.is_rog_ally_series():
     return rog_ally.get_current_charge_limit()
+  if uses_conservation_mode():
+    return lenovo.get_current_charge_limit()
   return 100
 
 def supports_charge_limit():
   if device_utils.is_rog_ally_series() and rog_ally.supports_charge_limit():
+    return True
+  if uses_conservation_mode():
     return True
   return False
 
@@ -32,6 +42,16 @@ def set_charge_limit(limit):
 
   if device_utils.is_rog_ally_series():
     return rog_ally.set_charge_limit(limit)
+  if uses_conservation_mode():
+    return lenovo.set_charge_limit(True)
+  return False
+
+def set_conservation(enabled):
+  # Boolean charge-limit devices (Lenovo Legion): apply an explicit on/off
+  # state. Used by handle_advanced_option_change, where the persisted setting
+  # is still stale, so the value must be passed in directly.
+  if uses_conservation_mode():
+    return lenovo.set_charge_limit(bool(enabled))
   return False
 
 def get_expected_charge_limit():
@@ -42,7 +62,17 @@ def charge_limit_enabled():
   return get_nested_setting('advanced.enableChargeLimit')
 
 def initialize_charge_limit():
-  if supports_charge_limit() and charge_limit_enabled():
+  if not supports_charge_limit():
+    return
+
+  if uses_conservation_mode():
+    # Only enforce the "on" state automatically. Leave the hardware alone when
+    # the feature is disabled so we don't fight a BIOS/other-tool setting.
+    if charge_limit_enabled():
+      lenovo.set_charge_limit(True)
+    return
+
+  if charge_limit_enabled():
     current_limit = get_current_charge_limit()
     expected_limit = get_expected_charge_limit()
 

--- a/py_modules/charge_limit.py
+++ b/py_modules/charge_limit.py
@@ -3,9 +3,10 @@ from plugin_settings import get_nested_setting
 import device_utils
 from time import sleep
 
-def uses_conservation_mode():
-  # Lenovo Legion (ideapad conservation_mode) is a boolean ~80% cap, not a
-  # percentage slider. Gate on capability (node exists) rather than product id.
+def uses_boolean_charge_limit():
+  # Lenovo Legion exposes a fixed firmware ~80% cap (ideapad conservation_mode or
+  # power_supply charge_types) - a boolean toggle, not a percentage slider. Gate
+  # on capability (node exists) rather than product id.
   return (not device_utils.is_rog_ally_series()) and lenovo.supports_charge_limit()
 
 def get_range_info():
@@ -13,7 +14,7 @@ def get_range_info():
     default = 100
     step = 5
     return [[charge_limit_min(), 100], default, step]
-  # conservation-mode devices are boolean-only, no percentage range
+  # boolean charge-limit devices have no percentage range
   return None
 
 def charge_limit_min():
@@ -25,14 +26,14 @@ def charge_limit_min():
 def get_current_charge_limit():
   if device_utils.is_rog_ally_series():
     return rog_ally.get_current_charge_limit()
-  if uses_conservation_mode():
+  if uses_boolean_charge_limit():
     return lenovo.get_current_charge_limit()
   return 100
 
 def supports_charge_limit():
   if device_utils.is_rog_ally_series() and rog_ally.supports_charge_limit():
     return True
-  if uses_conservation_mode():
+  if uses_boolean_charge_limit():
     return True
   return False
 
@@ -42,15 +43,15 @@ def set_charge_limit(limit):
 
   if device_utils.is_rog_ally_series():
     return rog_ally.set_charge_limit(limit)
-  if uses_conservation_mode():
+  if uses_boolean_charge_limit():
     return lenovo.set_charge_limit(True)
   return False
 
-def set_conservation(enabled):
+def set_boolean_charge_limit(enabled):
   # Boolean charge-limit devices (Lenovo Legion): apply an explicit on/off
   # state. Used by handle_advanced_option_change, where the persisted setting
   # is still stale, so the value must be passed in directly.
-  if uses_conservation_mode():
+  if uses_boolean_charge_limit():
     return lenovo.set_charge_limit(bool(enabled))
   return False
 
@@ -65,7 +66,7 @@ def initialize_charge_limit():
   if not supports_charge_limit():
     return
 
-  if uses_conservation_mode():
+  if uses_boolean_charge_limit():
     # Only enforce the "on" state automatically. Leave the hardware alone when
     # the feature is disabled so we don't fight a BIOS/other-tool setting.
     if charge_limit_enabled():

--- a/py_modules/devices/lenovo.py
+++ b/py_modules/devices/lenovo.py
@@ -164,78 +164,132 @@ def wait_for_wmi_ready(timeout_seconds=10):
   decky_plugin.logger.warning(f"{__name__} WMI not ready after {timeout_seconds}s timeout")
   return False
 
-# --- Battery charge limit (ideapad conservation mode) ---
-# Lenovo Legion (incl. Legion Go 2) exposes the battery charge limit via the
-# ideapad_acpi "conservation mode" node - a boolean ~80% cap - NOT the ROG Ally
-# charge_control_end_threshold percentage node. It is root-writable, and the
-# Decky backend runs as root, so no acpi_call / WMI evaluation is needed.
+# --- Battery charge limit -------------------------------------------------
+# Lenovo Legion exposes a fixed firmware battery-conservation cap (~80%) through
+# one of two root-writable sysfs interfaces, depending on model / driver:
+#   1. ideapad "conservation_mode"  - boolean "1"/"0"           (some Legion models)
+#   2. power_supply "charge_types"  - "Long_Life"/"Standard"    (Legion Go, exposed
+#                                     by the lenovo-wmi-other battery extension)
+# Both are a firmware on/off cap, NOT a settable percentage, so the plugin drives
+# them as a single boolean toggle. The Decky backend runs as root, so we just
+# read/write sysfs - no acpi_call / WMI evaluation needed.
 
 CONSERVATION_MODE_GLOB = "/sys/bus/platform/devices/VPC2004:*/conservation_mode"
-CONSERVATION_MODE_PATH = None
-# In-memory cache of the last value we wrote. Reading conservation_mode round-trips
-# to the EC and can block for many seconds under contention, so we must NOT read it
-# on the polling hot path - we track our own writes instead.
-_last_conservation_written = None
+CHARGE_TYPES_GLOB = "/sys/class/power_supply/BAT*/charge_types"
+CHARGE_TYPE_LIMITED = "Long_Life"  # firmware ~80% conservation cap
+CHARGE_TYPE_FULL = "Standard"      # normal charge to 100%
+
+# Resolved once: _charge_limit_kind in {"conservation", "charge_types", None}.
+_charge_limit_kind = None
+_charge_limit_path = None
+_charge_limit_resolved = False
+# In-memory cache of the last value we wrote. Reading these nodes can round-trip
+# to the EC / WMI and block for many seconds under contention, so we must NOT
+# read them on the polling hot path - we track our own writes instead.
+_last_charge_limit_written = None
+
+def _charge_types_current_and_options(path):
+  # charge_types mirrors charge_behaviour formatting: "[Standard] Long_Life",
+  # where the bracketed token is the current value. Returns (current, [options]).
+  with open(path, "r") as f:
+    tokens = f.read().split()
+  current = None
+  options = []
+  for tok in tokens:
+    name = tok.strip("[]")
+    options.append(name)
+    if tok.startswith("[") and tok.endswith("]"):
+      current = name
+  return current, options
+
+def _resolve_charge_limit_iface():
+  # Detect which battery-conservation interface this device exposes (once).
+  global _charge_limit_kind, _charge_limit_path, _charge_limit_resolved
+  if _charge_limit_resolved:
+    return _charge_limit_kind, _charge_limit_path
+
+  try:
+    conservation = glob.glob(CONSERVATION_MODE_GLOB)
+    if conservation:
+      _charge_limit_kind = "conservation"
+      _charge_limit_path = conservation[0]
+    else:
+      for path in glob.glob(CHARGE_TYPES_GLOB):
+        try:
+          _, options = _charge_types_current_and_options(path)
+        except Exception:
+          continue
+        if CHARGE_TYPE_LIMITED in options:
+          _charge_limit_kind = "charge_types"
+          _charge_limit_path = path
+          break
+  except Exception as e:
+    decky_plugin.logger.error(f"{__name__} error resolving charge-limit interface: {e}")
+
+  _charge_limit_resolved = True
+  if _charge_limit_kind:
+    decky_plugin.logger.info(f"{__name__} charge-limit interface: {_charge_limit_kind} @ {_charge_limit_path}")
+  return _charge_limit_kind, _charge_limit_path
 
 def get_conservation_mode_path():
-  global CONSERVATION_MODE_PATH
-
-  if not CONSERVATION_MODE_PATH:
-    try:
-      matches = glob.glob(CONSERVATION_MODE_GLOB)
-      if matches:
-        CONSERVATION_MODE_PATH = matches[0]
-    except Exception as e:
-      decky_plugin.logger.error(f"{__name__} error finding conservation_mode path: {e}")
-
-  return CONSERVATION_MODE_PATH
+  # Back-compat shim: resolved charge-limit node path (either interface).
+  return _resolve_charge_limit_iface()[1]
 
 def supports_charge_limit():
-  return get_conservation_mode_path() is not None
+  kind, _ = _resolve_charge_limit_iface()
+  return kind is not None
 
-def get_conservation_mode():
-  # WARNING: reading this node can block for many seconds (EC round-trip), so do
-  # NOT call this from the polling hot path - prefer the cached _last_conservation_written.
-  path = get_conservation_mode_path()
+def _read_charge_limit_enabled():
+  # WARNING: may block (EC / WMI round-trip) - do NOT call on the polling hot
+  # path; prefer the cached _last_charge_limit_written.
+  kind, path = _resolve_charge_limit_iface()
   if not path:
     return None
   try:
-    with open(path, "r") as f:
-      return f.read().strip() == "1"
+    if kind == "conservation":
+      with open(path, "r") as f:
+        return f.read().strip() == "1"
+    current, _ = _charge_types_current_and_options(path)
+    return current == CHARGE_TYPE_LIMITED
   except Exception as e:
-    decky_plugin.logger.error(f"{__name__} error reading conservation_mode: {e}")
+    decky_plugin.logger.error(f"{__name__} error reading charge-limit state: {e}")
     return None
 
 def set_charge_limit(enabled) -> bool:
-  global _last_conservation_written
-  path = get_conservation_mode_path()
+  global _last_charge_limit_written
+  kind, path = _resolve_charge_limit_iface()
   if not path:
-    decky_plugin.logger.info(f"{__name__} conservation_mode path not found")
+    decky_plugin.logger.info(f"{__name__} no charge-limit interface found")
     return False
 
   desired = bool(enabled)
   # Skip if we already wrote this value. This is what makes the per-poll
   # re-assert cheap: no blocking read, and only one write per state change.
-  if _last_conservation_written == desired:
+  if _last_charge_limit_written == desired:
     return True
 
+  if kind == "conservation":
+    value = "1" if desired else "0"
+  else:  # charge_types
+    value = CHARGE_TYPE_LIMITED if desired else CHARGE_TYPE_FULL
+
   try:
-    decky_plugin.logger.info(f"{__name__} setting conservation_mode to {'1' if desired else '0'}")
+    decky_plugin.logger.info(f"{__name__} setting {kind} charge limit to '{value}'")
     with open(path, "w") as f:
-      f.write("1" if desired else "0")
-    _last_conservation_written = desired
+      f.write(value)
+    _last_charge_limit_written = desired
     return True
   except Exception as e:
-    decky_plugin.logger.error(f"{__name__} error writing conservation_mode: {e}")
+    decky_plugin.logger.error(f"{__name__} error writing charge limit ({kind}): {e}")
     return False
 
 def get_current_charge_limit():
   # Return a percentage-like value for API compatibility with the ROG Ally path:
   # ~80 when the conservation cap is on, 100 when off. Prefer the cached state to
   # avoid a potentially-slow sysfs read; only fall back to reading the node once.
-  if _last_conservation_written is not None:
-    return 80 if _last_conservation_written else 100
-  mode = get_conservation_mode()
-  if mode is None:
+  if _last_charge_limit_written is not None:
+    return 80 if _last_charge_limit_written else 100
+  enabled = _read_charge_limit_enabled()
+  if enabled is None:
     return 100
-  return 80 if mode else 100
+  return 80 if enabled else 100

--- a/py_modules/devices/lenovo.py
+++ b/py_modules/devices/lenovo.py
@@ -1,4 +1,5 @@
 import decky_plugin
+import glob
 import os
 from time import sleep
 
@@ -162,3 +163,79 @@ def wait_for_wmi_ready(timeout_seconds=10):
     elapsed += interval
   decky_plugin.logger.warning(f"{__name__} WMI not ready after {timeout_seconds}s timeout")
   return False
+
+# --- Battery charge limit (ideapad conservation mode) ---
+# Lenovo Legion (incl. Legion Go 2) exposes the battery charge limit via the
+# ideapad_acpi "conservation mode" node - a boolean ~80% cap - NOT the ROG Ally
+# charge_control_end_threshold percentage node. It is root-writable, and the
+# Decky backend runs as root, so no acpi_call / WMI evaluation is needed.
+
+CONSERVATION_MODE_GLOB = "/sys/bus/platform/devices/VPC2004:*/conservation_mode"
+CONSERVATION_MODE_PATH = None
+# In-memory cache of the last value we wrote. Reading conservation_mode round-trips
+# to the EC and can block for many seconds under contention, so we must NOT read it
+# on the polling hot path - we track our own writes instead.
+_last_conservation_written = None
+
+def get_conservation_mode_path():
+  global CONSERVATION_MODE_PATH
+
+  if not CONSERVATION_MODE_PATH:
+    try:
+      matches = glob.glob(CONSERVATION_MODE_GLOB)
+      if matches:
+        CONSERVATION_MODE_PATH = matches[0]
+    except Exception as e:
+      decky_plugin.logger.error(f"{__name__} error finding conservation_mode path: {e}")
+
+  return CONSERVATION_MODE_PATH
+
+def supports_charge_limit():
+  return get_conservation_mode_path() is not None
+
+def get_conservation_mode():
+  # WARNING: reading this node can block for many seconds (EC round-trip), so do
+  # NOT call this from the polling hot path - prefer the cached _last_conservation_written.
+  path = get_conservation_mode_path()
+  if not path:
+    return None
+  try:
+    with open(path, "r") as f:
+      return f.read().strip() == "1"
+  except Exception as e:
+    decky_plugin.logger.error(f"{__name__} error reading conservation_mode: {e}")
+    return None
+
+def set_charge_limit(enabled) -> bool:
+  global _last_conservation_written
+  path = get_conservation_mode_path()
+  if not path:
+    decky_plugin.logger.info(f"{__name__} conservation_mode path not found")
+    return False
+
+  desired = bool(enabled)
+  # Skip if we already wrote this value. This is what makes the per-poll
+  # re-assert cheap: no blocking read, and only one write per state change.
+  if _last_conservation_written == desired:
+    return True
+
+  try:
+    decky_plugin.logger.info(f"{__name__} setting conservation_mode to {'1' if desired else '0'}")
+    with open(path, "w") as f:
+      f.write("1" if desired else "0")
+    _last_conservation_written = desired
+    return True
+  except Exception as e:
+    decky_plugin.logger.error(f"{__name__} error writing conservation_mode: {e}")
+    return False
+
+def get_current_charge_limit():
+  # Return a percentage-like value for API compatibility with the ROG Ally path:
+  # ~80 when the conservation cap is on, 100 when off. Prefer the cached state to
+  # avoid a potentially-slow sysfs read; only fall back to reading the node once.
+  if _last_conservation_written is not None:
+    return 80 if _last_conservation_written else 100
+  mode = get_conservation_mode()
+  if mode is None:
+    return 100
+  return 80 if mode else 100


### PR DESCRIPTION
## Summary

Adds a battery charge-limit toggle for Lenovo Legion handhelds in Advanced Options. Legion devices cap the battery at a fixed firmware ~80% ("conservation") level rather than exposing the ROG Ally's `charge_control_end_threshold` percentage interface, so this is a boolean **"Enable Battery Charge Limit"** toggle — no percentage slider.

Different Legion models expose that cap through **different sysfs interfaces**, so the backend auto-detects whichever is present:

| Interface | Node | On / Off values | Verified on |
|-----------|------|-----------------|-------------|
| ideapad `conservation_mode` | `/sys/bus/platform/devices/VPC2004:*/conservation_mode` | `1` / `0` | Legion Go 2 (`83N0`) |
| power_supply `charge_types` | `/sys/class/power_supply/BAT*/charge_types` | `Long_Life` / `Standard` | Legion Go (`83E1`) |

The original Legion Go (`83E1`) does **not** expose `conservation_mode`; it exposes the cap via the `charge_types` node (provided by the `lenovo-wmi-other` battery extension — the same WMI driver behind the `ppt_*` TDP attributes). Both nodes are root-writable and the Decky backend runs as root, so no `acpi_call` / WMI evaluation is needed.

## Changes

- `py_modules/devices/lenovo.py` — resolve the charge-limit interface once (`conservation_mode`, else a `charge_types` node advertising `Long_Life`); read/write the correct node and value per interface; in-memory write cache (see design notes)
- `py_modules/charge_limit.py` — `uses_boolean_charge_limit()` capability gate + Legion dispatch for `supports` / `get` / `set`; boolean-only (no % slider)
- `py_modules/advanced_options.py` — emit the toggle when supported, and hoist the charge-limit apply out of the ROG-Ally-only branch so it runs for any supported device; device-specific description
- `defaults/i18n/{en,template}.json` — new `ADVANCED_ENABLE_CHARGE_LIMIT_DESC` / `_CONSERVATION_DESC` keys

## Design notes

- **Capability-gated, not device-ID-gated.** Enabled when either interface node is present, so it lights up on any Lenovo handheld that exposes a firmware charge cap and is a no-op elsewhere. `device_utils.py` / TDP behavior is unchanged.
- **Boolean, not a percentage.** These devices only offer a fixed ~80% cap — no `charge_control_end_threshold` — so the ROG Ally percentage slider is intentionally not shown for Legion.
- **No blocking reads on the poll path.** Reading these nodes round-trips to the EC / WMI and can block for many seconds under contention. Since `initialize_charge_limit()` re-asserts on every TDP poll, the Legion path is write-only and guarded by an in-memory cache, so it's a no-op once applied (avoids stalling the plugin).
- `initialize_charge_limit()` only enforces the "on" state, leaving the hardware alone when disabled so it won't fight a BIOS / other-tool setting.

## Testing

- **Legion Go 2 (`83N0`)** — `conservation_mode` path: toggling flips `/sys/bus/platform/devices/VPC2004:00/conservation_mode` between `1` / `0`; battery charges to ~80% and holds (drained to 74%, watched it recharge to ~80% and stop).
- **Legion Go (`83E1`)** — `charge_types` path: the toggle moves `charge_types` between `[Standard]` and `[Long_Life]`; with `Long_Life` set the battery holds at ~80%.

Backend-only change; no frontend rebuild required (the option renderer and enums already exist).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
