### PR TITLE
feat(legion-go): detect Legion Go 2 (83N0 / 83N1)

### DIFF
--- a/py_modules/device_utils.py
+++ b/py_modules/device_utils.py
@@ -5,6 +5,8 @@ import re
 
 class Devices(Enum):
   LEGION_GO = "83E1"
+  LEGION_GO_2_Z2_EXTREME = "83N0"
+  LEGION_GO_2_Z2 = "83N1"
   LEGION_GO_S_Z2_GO = "83L3"
   LEGION_GO_S_Z1_EXTREME = "83N6"
   ROG_ALLY = "ROG Ally RC71"
@@ -129,6 +131,10 @@ def is_legion_go():
   device_name = get_device_name()
 
   if device_name == Devices.LEGION_GO.value:
+    return True
+  if device_name == Devices.LEGION_GO_2_Z2_EXTREME.value:
+    return True
+  if device_name == Devices.LEGION_GO_2_Z2.value:
     return True
   if device_name == Devices.LEGION_GO_S_Z2_GO.value:
     return True


### PR DESCRIPTION
## Summary

Detects the **Lenovo Legion Go 2** as a Legion Go. Adds both Go 2 SKUs to the `Devices` enum and `is_legion_go()`, following the existing by-CPU naming convention:

- `LEGION_GO_2_Z2_EXTREME = "83N0"` (Ryzen Z2 Extreme)
- `LEGION_GO_2_Z2 = "83N1"` (Ryzen Z2)

## Why

On the Go 2, `is_legion_go()` currently returns `False`, so the device misses the Legion-specific handling even though it exposes the same interfaces as other supported Legion devices:

- the **"Lenovo Custom TDP Mode"** advanced option (gated on `is_legion_go() and lenovo.supports_wmi_tdp()`)
- the on-resume Lenovo WMI cache invalidation / `wait_for_wmi_ready()` in `main.py`

Verified on a Legion Go 2 Z2 Extreme (`83N0`): `lenovo-wmi-other-0` exposes the `ppt_*` attributes and `platform-profile-1 = lenovo-wmi-gamezone` is present, so `lenovo.supports_wmi_tdp()` returns `True`.

## Changes

- `py_modules/device_utils.py`: add `LEGION_GO_2_Z2_EXTREME = "83N0"` and `LEGION_GO_2_Z2 = "83N1"` to `Devices`, and match them in `is_legion_go()`.

## Testing

On a Legion Go 2 Z2 Extreme (`83N0`), `is_legion_go()` now returns `True`. The standard Z2 SKU (`83N1`) is included for completeness (untested — I only have an `83N0` unit).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
