### PR TITLE
feat(tdp): firmware-declared TDP slider range for Lenovo Legion

### DIFF
--- a/main.py
+++ b/main.py
@@ -69,6 +69,14 @@ class Plugin:
             min_tdp, max_tdp = cpu_utils.get_intel_tdp_limits()
             settings['maxTdp'] = max_tdp
             settings['minTdp'] = min_tdp
+          else:
+            # firmware-declared per-device TDP range (e.g. Lenovo Legion WMI).
+            # setdefault so a user's saved custom range is not overwritten.
+            tdp_range = cpu_utils.get_default_tdp_range()
+            if tdp_range:
+              dev_min, dev_max = tdp_range
+              settings.setdefault('minTdp', dev_min)
+              settings.setdefault('maxTdp', dev_max)
 
           gpu_min, gpu_max = get_gpu_frequency_range()
           if (gpu_min and gpu_max):

--- a/py_modules/cpu_utils.py
+++ b/py_modules/cpu_utils.py
@@ -345,6 +345,17 @@ def get_intel_tdp_limits():
     max_tdp = get_intel_max_tdp()
   return [min_tdp, max_tdp]
 
+def get_default_tdp_range():
+  # Firmware-declared TDP range for the main slider on non-Intel devices.
+  # Lenovo Legion exposes WMI ppt min/max (e.g. Legion Go 2 = [5, 35]).
+  # Returns None when no device-specific range is known, so the frontend
+  # falls back to its default.
+  if lenovo.supports_wmi_tdp():
+    min_tdp, max_tdp = lenovo.get_tdp_limit(lenovo.STAPM_SUFFIX)
+    if isinstance(min_tdp, int) and isinstance(max_tdp, int):
+      return [min_tdp, max_tdp]
+  return None
+
 def get_intel_max_tdp():
   tdp_prefix = INTEL_LEGACY_TDP_PREFIX if use_legacy_intel_tdp() else INTEL_TDP_PREFIX
 


### PR DESCRIPTION
## Summary

Uses the **firmware-declared TDP range** for the main TDP slider on Lenovo Legion devices, instead of the generic `3–15 W` fallback.

## Background

The main slider reads `minTdp`/`maxTdp` from the backend `get_settings()` response (falling back to `3`/`15` in the frontend). Today only **Intel** gets a backend-computed range (from RAPL `constraint_0_max_power_uw`). Non-Intel devices — including Legion Go — fall through to `3–15 W`, even though the hardware publishes an accurate range.

## Changes

- `py_modules/cpu_utils.py` — add `get_default_tdp_range()`: returns the Lenovo Legion WMI `ppt_pl1_spl` (STAPM) `min_value`/`max_value` when `lenovo.supports_wmi_tdp()`, else `None`.
- `main.py` `get_settings()` — for non-Intel devices, apply the range with `setdefault` so a user's saved custom range is never overwritten.

## Design notes

- **Capability-gated, not device-ID-gated.** It reads `lenovo.supports_wmi_tdp()` (the WMI ppt attrs + `lenovo-wmi-gamezone` platform profile), so it's a no-op on any device without those firmware attributes and doesn't depend on the device being in the `Devices` enum. (Complements — but does not require — Legion Go 2 detection.)
- **Backend-only, no rebuild.** Same path the existing Intel/GPU-frequency ranges already use to reach the slider.
- Uses the sustained/STAPM limit (`ppt_pl1_spl`) for the ceiling; the slow/fast limits (`ppt_pl2_sppt`/`ppt_pl3_fppt`) are higher, but the sustained value is the right bound for the main "TDP" slider.

## Testing

On a Legion Go 2 (`83N0`), `get_default_tdp_range()` returns `[5, 35]` (matching the firmware `ppt_pl1_spl` min/max), and the main TDP slider defaults to `5–35 W`. No-op verified for non-Lenovo devices (returns `None` → frontend `3–15` fallback unchanged).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
